### PR TITLE
Add function split_words_by

### DIFF
--- a/include/fplus/split.h
+++ b/include/fplus/split.h
@@ -106,33 +106,21 @@ template <typename UnaryPredicate, typename ContainerIn,
 ContainerOut split_by
         (UnaryPredicate pred, bool allowEmpty, const ContainerIn& xs)
 {
-    typedef typename ContainerIn::value_type T;
-    typedef typename ContainerOut::value_type ContainerOutInner;
     check_unary_predicate_for_container<UnaryPredicate, ContainerIn>();
     static_assert(std::is_same<ContainerIn, typename ContainerOut::value_type>::value, "Containers do not match.");
+
     ContainerOut result;
     auto itOut = get_back_inserter(result);
-    ContainerOutInner current;
-    auto itOutCurrent = get_back_inserter(current);
-    for (const T& x : xs)
+    auto start = std::begin(xs);
+    while (start != std::end(xs) && *start)
     {
-        if (pred(x))
+        const auto stop = std::find_if(start, std::end(xs), pred);
+        if (start != stop || allowEmpty)
         {
-            if (is_not_empty(current) || allowEmpty)
-            {
-                *itOut = current;
-                current.clear();
-                itOutCurrent = get_back_inserter(current);
-            }
+            *itOut = { start, stop };
         }
-        else
-        {
-            *itOutCurrent = x;
-        }
-    }
-    if (is_not_empty(current) || allowEmpty)
-    {
-        *itOut = current;
+        if (stop == std::end(xs)) break;
+        start = std::next(stop);
     }
     return result;
 }

--- a/include/fplus/string_tools.h
+++ b/include/fplus/string_tools.h
@@ -48,12 +48,39 @@ String clean_newlines(const String& str)
         replace_tokens(String("\r\n"), String("\n"), str));
 }
 
-// Splits a string by the found whitespace characters.
-// split_words("How are you?") == ["How", "are", "you?"]
+// Splits a string by non-letter and non-digit characters.
+// split_words("How are you?") == ["How", "are", "you"]
 template <typename String, typename ContainerOut = std::vector<String>>
 ContainerOut split_words(const String& str)
 {
     return split_by(logical_not(is_letter_or_digit<String>), false, str);
+}
+
+// Splits a string by non-letter and non-digit characters.
+// split_words("How-are you?", ' ') == ["How-are", "you?"]
+template <typename String, typename ContainerOut = std::vector<String>>
+ContainerOut split_words_by
+        (const String& str, const typename String::value_type delim)
+{
+    const auto comparator = [delim](const typename String::value_type ch)
+    {
+        return ch == delim;
+    };
+    return split_by(comparator, false, str);
+}
+
+// Splits a string by non-letter and non-digit characters.
+// split_words("How are you?", "- o") == ["H", "w", "are", "y", "u?"]
+template <typename String, typename ContainerOut = std::vector<String>>
+ContainerOut split_words_by(const String& str, const String& delims)
+{
+    typedef typename String::value_type CharType;
+    const auto comparator = [&delims](const CharType ch)
+    {
+        return std::any_of(std::begin(delims), std::end(delims),
+                    [ch](const CharType delim) { return ch == delim; });
+    };
+    return split_by(comparator, false, str);
 }
 
 // Splits a string by the found newlines.

--- a/include/fplus/string_tools.h
+++ b/include/fplus/string_tools.h
@@ -51,28 +51,30 @@ String clean_newlines(const String& str)
 // Splits a string by non-letter and non-digit characters.
 // split_words("How are you?") == ["How", "are", "you"]
 template <typename String, typename ContainerOut = std::vector<String>>
-ContainerOut split_words(const String& str)
+ContainerOut split_words(const String& str, const bool allowEmpty = false)
 {
-    return split_by(logical_not(is_letter_or_digit<String>), false, str);
+    return split_by(logical_not(is_letter_or_digit<String>), allowEmpty, str);
 }
 
 // Splits a string by non-letter and non-digit characters.
 // split_words("How-are you?", ' ') == ["How-are", "you?"]
 template <typename String, typename ContainerOut = std::vector<String>>
 ContainerOut split_words_by
-        (const String& str, const typename String::value_type delim)
+        (const String& str, const typename String::value_type delim,
+         const bool allowEmpty = false)
 {
     const auto comparator = [delim](const typename String::value_type ch)
     {
         return ch == delim;
     };
-    return split_by(comparator, false, str);
+    return split_by(comparator, allowEmpty, str);
 }
 
 // Splits a string by non-letter and non-digit characters.
 // split_words("How are you?", "- o") == ["H", "w", "are", "y", "u?"]
 template <typename String, typename ContainerOut = std::vector<String>>
-ContainerOut split_words_by(const String& str, const String& delims)
+ContainerOut split_words_by
+        (const String& str, const String& delims, const bool allowEmpty = false)
 {
     typedef typename String::value_type CharType;
     const auto comparator = [&delims](const CharType ch)
@@ -80,7 +82,7 @@ ContainerOut split_words_by(const String& str, const String& delims)
         return std::any_of(std::begin(delims), std::end(delims),
                     [ch](const CharType delim) { return ch == delim; });
     };
-    return split_by(comparator, false, str);
+    return split_by(comparator, allowEmpty, str);
 }
 
 // Splits a string by the found newlines.

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -896,12 +896,26 @@ void Test_StringTools()
         std::string("a"),
         std::string("strange"),
         std::string("string") };
+    std::vector<std::string> textSplitBySpaceOnly = {
+        std::string("Hi,\nI"),
+        std::string("am"),
+        std::string("a\r\n***strange***\n\rstring.") };
+    std::vector<std::string> textSplitBySpaceAndCommaAndLine = {
+        std::string("Hi"),
+        std::string("I"),
+        std::string("am"),
+        std::string("a"),
+        std::string("***strange***"),
+        std::string("string.") };
 
     assert(split_lines(text, true)
             == textAsLinesWithEmty);
     assert(split_lines(text, false)
             == textAsLinesWithoutEmpty);
     assert(split_words(text) == textAsWords);
+    assert(split_words_by(text, ' ') == textSplitBySpaceOnly);
+    assert(split_words_by(text, std::string{ " ,\r\n" }) == textSplitBySpaceAndCommaAndLine);
+
     assert(to_string_fill_left('0', 5, 42) == std::string("00042") );
     assert(to_string_fill_right(' ', 5, 42) == std::string("42   ") );
 }


### PR DESCRIPTION
This PR address Issue #5 

A few notes:

1. It turns out that the original `split_by` function was not *that* inefficient compared to the new version (it was slower but not 10x slower). What was actually the problem was that `split_words` calls `split_by` like this: `split_by(logical_not(is_letter_or_digit<String>), false, str);`
This causes the predicate to check for everything that's not a letter or digit, meaning it has to compare against many, many ascii characters <del>(or more if widechar is used)</del> for each character in `str`. This is an unnecessary overhead in cases where users only want to split by a single character.

2. A function `split_words_by` is added to accept a string and a delimiter, and splits by comparing against what's *not* equal to the delimiter.

3. `split_words_by` has an overload that takes a range of delimiters to split on. 

4. I also added a default parameter `bool allowEmpty = false` to `split_words` and `split_words_by` to give more flexibility to the users in letting them choose whether to keep empty tokens. It's defaulted to false to preserve backwards compatibility.

5. There was an issue with the comment describing `split_words`. It said `// split_words("How are you?") == ["How", "are", "you?"]`, which isn't true because your `split_words` will remove all non-digit and non-letter characters, so "you?" will become "you".

6. `string_tools.h` has Windows-style line endings while `test.cpp` and `split.h` have Unix-style line endings. I kept the endings consistent to the files, but that was weird. :P

Here are the new benchmarks (note that this is run on a more powerful machine compared to Issue #5, so the baseline is different)
```
Time taken: 16.0496s (fplus::split_words)
Time taken: 1.60925s (fplus::split_words_by)
```
```c++
#include <chrono>
#include <iostream>
#include "fplus.h"

template <typename Splitter>
void measure(const std::string &label, const Splitter &splitter) {
    using namespace std::chrono;

    const auto start_time = high_resolution_clock::now();
    for (auto _ = 0; _ < 5000000; _++) {
        splitter();
    }
    const auto elapsed = high_resolution_clock::now() - start_time;
    std::cout << "Time taken: " << duration_cast<duration<double>>(elapsed).count();
    std::cout << "s " << label << std::endl;
}

int main() {
    const auto words = std::string{ "a bb ccc dddd eeeee ffffff ggggggg hhhhhhhhh" };
    measure("(fplus::split_words)",    [words]() { fplus::split_words(words); });
    measure("(fplus::split_words_by)", [words]() { fplus::split_words_by(words, ' '); });
}
```