### PR TITLE
Add cmake to build and run tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+cmake_minimum_required(VERSION 2.8)
+
+install (DIRECTORY include/fplus DESTINATION include)
+install (FILES include/fplus.h DESTINATION include)
+
+include(CTest)
+
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -VV -C ${CMAKE_CFG_INTDIR})
+
+function(add_test_executable TEST_NAME)
+    add_executable (${TEST_NAME} EXCLUDE_FROM_ALL ${ARGN})
+    if(WIN32)
+        add_test(NAME ${TEST_NAME} WORKING_DIRECTORY ${LIBRARY_OUTPUT_PATH} COMMAND ${TEST_NAME}${CMAKE_EXECUTABLE_SUFFIX})
+    else()
+        add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+    endif()
+    add_dependencies(check ${TEST_NAME})
+endfunction(add_test_executable)
+
+find_package(Threads)
+
+include_directories(include)
+add_test_executable(tests test/tests.cpp)
+target_link_libraries(tests ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
This adds an initial cmake. On unix based system it can build, run the tests, and install like this:

```
mkdir build
cd build
# Set cxx flags if they are not already set by the toolchain
CXXFLAGS='-std=c++11' cmake ..
# Build and run the tests
cmake --build . --target check
# Install the library
cmake --build . --target install
```

For MSVC, you would just omit the `CXXFLAGS='-std=c++11'` setting.

Also, with standard cmake packaging support this can be installed with [cget](https://github.com/pfultz2/cget/) as well:

```
# Setup up toolchain to use c++11
cget init --std=c++11
# Test and install
cget install --test Dobiasd/FunctionalPlus
```