### PR TITLE
Missing include for cmath added to get tests compiling under Gcc6

### DIFF
--- a/include/fplus/numeric.h
+++ b/include/fplus/numeric.h
@@ -9,6 +9,7 @@
 #include "function_traits.h"
 #include <functional>
 #include <limits>
+#include <cmath>
 
 namespace fplus
 {


### PR DESCRIPTION
Without the include Gcc6 failed to compile the tests.