### PR TITLE
CMake for C++11 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ include(CTest)
 
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -VV -C ${CMAKE_CFG_INTDIR})
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(Cpp11)
+
 function(add_test_executable TEST_NAME)
     add_executable (${TEST_NAME} EXCLUDE_FROM_ALL ${ARGN})
     if(WIN32)

--- a/cmake/Cpp11.cmake
+++ b/cmake/Cpp11.cmake
@@ -1,0 +1,14 @@
+
+include(CheckCXXCompilerFlag)
+
+CHECK_CXX_COMPILER_FLAG("-std=c++11" CPP_STD_11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" CPP_STD_0x)
+
+if( CPP_STD_11 )
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+elseif( CPP_STD_0x )
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+else()
+    message(WARNING "C++11 not supported by ${CMAKE_CXX_COMPILER}")
+endif()
+


### PR DESCRIPTION
Checks if the compiler supports either `-std=c++11` or `-std=0x`<sup>1)</sup> and adds the compilerflag if available. If none of them a warning is shown.

`CXXFLAGS='-std=c++11'` is not required any more, it's detected automatically now:

```
mkdir build
cmake ..
make check
make install
```

If the warning is a problem for VC++, it's possible to do the test only for gcc / clang.