### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: generic
+
+cache:
+    apt: true
+
+matrix:
+    include:
+    - env: CXX=g++-6 CC=gcc-6
+      addons:
+        apt:
+          packages:
+            - g++-6
+            - cmake
+          sources: &sources
+            - ubuntu-toolchain-r-test
+            - kalakris-cmake
+    - env: CXX=g++-5 CC=gcc-5
+      addons:
+        apt:
+          packages:
+            - g++-5
+            - cmake
+          sources: *sources
+    - env: CXX=g++-4.9 CC=gcc-4.9
+      addons:
+        apt:
+          packages:
+            - g++-4.9
+            - cmake
+          sources: *sources
+    - env: CXX=g++-4.8 CC=gcc-4.8
+      addons:
+        apt:
+          packages:
+            - g++-4.8
+            - cmake
+          sources: *sources
+
+script:
+    - mkdir build && cd build
+    - cmake ..
+    - make
+    - make check
+


### PR DESCRIPTION
Enables [Travis CI](https://travis-ci.org/) using Gcc 4.8, 4.9, 5.x and 6.x. Clang is not available at the moment (Repository down).