### PR TITLE
GTest headers added as system includes to prevent Weffc++ warnings if

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ macro(_add_test _NAME)
     add_executable(${_NAME} ${_NAME}.cpp)
     add_test(NAME ${_NAME} COMMAND ${_NAME})
 
-    target_include_directories(${_NAME} PUBLIC
+    target_include_directories(${_NAME} SYSTEM PUBLIC
                                 ${GTest_INCLUDE_DIR}
                                 ${GMock_INCLUDE_DIR}
                                 )


### PR DESCRIPTION
This is a small fix that adds gtest includes as system includes. If Gtest is not installed to system include paths, the `Weffc++` Warning prevents the FunctionalPlus tests from building.