### PR TITLE
CI: Clang builds added (fixes #39).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
             - g++-6
           sources: &sources
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise
+            - llvm-toolchain-precise-3.8
+            - llvm-toolchain-precise-3.7
+            - llvm-toolchain-precise-3.6
     - env: CXX=g++-5 CC=gcc-5
       addons:
         apt:
@@ -32,6 +36,24 @@ matrix:
         apt:
           packages:
             - g++-4.8
+          sources: *sources
+    - env: CXX=clang++-3.8 CC=clang-3.8
+      addons:
+        apt:
+          packages:
+            - clang-3.8
+          sources: *sources
+    - env: CXX=clang++-3.7 CC=clang-3.7
+      addons:
+        apt:
+          packages:
+            - clang-3.7
+          sources: *sources
+    - env: CXX=clang++-3.6 CC=clang-3.6
+      addons:
+        apt:
+          packages:
+            - clang-3.6
           sources: *sources
 
 script:

--- a/test/container_common_test.cpp
+++ b/test/container_common_test.cpp
@@ -246,7 +246,6 @@ TEST(container_common_test, combination)
 {
     using namespace fplus;
     typedef std::vector<std::list<int>> intListVec;
-    std::string ABCD("ABCD");
     EXPECT_EQ(combinations(2, ABCD), string_vec({"AB", "AC", "AD", "BC", "BD", "CD"}));
     EXPECT_EQ(combinations(1, ABCD), string_vec({"A", "B", "C", "D"}));
     EXPECT_EQ(combinations(3, ABCD), string_vec({"ABC", "ABD", "ACD", "BCD"}));


### PR DESCRIPTION
Adds clang (3.6, 3.7, 3.8) to CI builds – see #39.

**Note:** The clang builds fail due shadowed variables, this needs a fix before merge.
