### PR TITLE
Travis CI shield replaced by a HQ one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![logo](logo/fplus.png)
 
-
-[![(Travis image broken)](https://travis-ci.org/Dobiasd/FunctionalPlus.png?branch=master)][travis]
+[![Build Status](https://travis-ci.org/Dobiasd/FunctionalPlus.svg?branch=master)](travis)
 [![(License Boost 1.0)](https://img.shields.io/badge/license-boost%201.0-blue.svg)][license]
 
 [travis]: https://travis-ci.org/Dobiasd/FunctionalPlus


### PR DESCRIPTION
The default Travis CI build status shield has low quality (compared to the license shield). This PR replaces it by a HQ one.