### PR TITLE
Clang 3.9 added to CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
             - llvm-toolchain-precise-3.8
             - llvm-toolchain-precise-3.7
             - llvm-toolchain-precise-3.6
+            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main'
+              key_url: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
     - env: CXX=g++-5 CC=gcc-5
       addons:
         apt:
@@ -36,6 +38,13 @@ matrix:
         apt:
           packages:
             - g++-4.8
+          sources: *sources
+    - env: CXX=clang++-3.9 CC=clang-3.9
+      addons:
+        apt:
+          packages:
+            - clang-3.9
+            - libc++-dev
           sources: *sources
     - env: CXX=clang++-3.8 CC=clang-3.8
       addons:


### PR DESCRIPTION
Clang 3.9 build added to CI. [Since 3.9 is not whitelisted](https://github.com/travis-ci/apt-source-whitelist/issues/300) (yet), it's added through a sourceline. In practice this doesn't make any difference. Once clang 3.9 is enabled by travis, we can switch to ppa.