### PR TITLE
CMake: proper searching for doctest added

### DIFF
--- a/cmake/Finddoctest.cmake
+++ b/cmake/Finddoctest.cmake
@@ -1,0 +1,20 @@
+find_package(PkgConfig)
+pkg_check_modules(PKG_doctest QUIET doctest)
+set(doctest_DEFINITIONS ${PKG_doctest_CFLAGS_OTHER})
+
+find_path(doctest_INCLUDE_DIR "doctest.h"
+                                HINTS ${PKG_doctest_INCLUDE_DIRS}
+                                        "${doctest_DIR}/include"
+                                )
+
+set(doctest_INCLUDE_DIRS ${doctest_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(doctest DEFAULT_MSG
+                                        doctest_INCLUDE_DIR
+                                        )
+
+mark_as_advanced(doctest_INCLUDE_DIR)
+
+
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,14 +1,15 @@
 
 message(STATUS "Building Unit Tests ${UNITTEST}")
 
+find_package(doctest REQUIRED)
+
+
 macro(_add_test _NAME)
     add_executable(${_NAME} ${_NAME}.cpp)
     add_test(NAME ${_NAME} COMMAND ${_NAME})
 
-    target_include_directories(${_NAME} SYSTEM PUBLIC
-                                )
-    target_link_libraries(${_NAME} ${CMAKE_THREAD_LIBS_INIT}
-                                    )
+    target_include_directories(${_NAME} SYSTEM PUBLIC ${doctest_INCLUDE_DIR})
+    target_link_libraries(${_NAME} ${CMAKE_THREAD_LIBS_INIT})
 endmacro()
 
 _add_test(compare_test)


### PR DESCRIPTION
Some CMake related changes according doctest:

- Proper searching for doctest added 
- Include path set for test targets