### PR TITLE
Enable libc++ for clang builds

### DIFF
--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [[ "$CXX" == clang* ]]; then
+    export CXXFLAGS="-stdlib=libc++"
+fi
+
 [ ! -d build ] && mkdir build
 (
     pushd build


### PR DESCRIPTION
This is a fix for #59. 

@Dobiasd  This build [fails on (all) clang](https://travis-ci.org/offa/FunctionalPlus/builds/184998958) but for a different reason.