### PR TITLE
Clang 4.0 ci build added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
             - llvm-toolchain-precise-3.8
             - llvm-toolchain-precise-3.7
             - llvm-toolchain-precise-3.6
+            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
+              key_url: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
     - env: CXX=g++-5 CC=gcc-5
       addons:
         apt:
@@ -31,6 +33,13 @@ matrix:
         apt:
           packages:
             - g++-4.9
+          sources: *sources
+    - env: CXX=clang++-4.0 CC=clang-4.0
+      addons:
+        apt:
+          packages:
+            - clang-4.0
+            - libc++-dev
           sources: *sources
     - env: CXX=clang++-3.9 CC=clang-3.9
       addons:


### PR DESCRIPTION
Clang 4.0 ci build added. If the number of builds is to high, we can drop clang 3.6.