### PR TITLE
Apt Cache setting removed from CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: generic
 dist: trusty
 sudo: required
 
-cache:
-    apt: true
-
 matrix:
     include:
     - env: CXX=g++-7 CC=gcc-7


### PR DESCRIPTION
Apt Cache setting removed from CI config, as this is actually not supported by Travis.