### PR TITLE
doc: cmake external project

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,12 +380,14 @@ You can also add `FunctionalPlus` as an `ExternalProject` to your CMakeLists.
 The benefits of this:
 
 - No installation
-- Better version control by setting the `GIT_TAG`
-  - You can always get the latest version by setting it to `master`
-  - Or you can get the specific version by setting it to a specific commit point 
+- Better version control with the `GIT_TAG`
+  - Always get the latest version when `GIT_TAG master`
+  - When you builds your project, it will automatically update the headers if there is a change
+  - Or get the specific version by setting it to a specific commit point
 
 
-```
+
+```cmake
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(FplusMinimalExternalExample)
 set(CMAKE_CXX_STANDARD 14)

--- a/README.md
+++ b/README.md
@@ -373,6 +373,45 @@ cmake -DUNITTEST=ON -DCPP14TEST=ON ..
 make unittest
 ```
 
+### using [cmake's ExternalProject](https://cmake.org/cmake/help/v3.0/module/ExternalProject.html)
+
+You can also add `FunctionalPlus` as an `ExternalProject` to your CMakeLists.
+
+The benefits of this:
+
+- No installation
+- Better version control by setting the `GIT_TAG`
+  - You can always get the latest version by setting it to `master`
+  - Or you can get the specific version by setting it to a specific commit point 
+
+
+```
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+project(FplusMinimalExternalExample)
+set(CMAKE_CXX_STANDARD 14)
+
+include(ExternalProject)
+ExternalProject_Add(functional_plus
+  GIT_REPOSITORY https://github.com/Dobiasd/FunctionalPlus.git
+  GIT_TAG master
+
+  SOURCE_DIR "${CMAKE_BINARY_DIR}/thirdparty/fplus"
+
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+
+  LOG_DOWNLOAD ON
+  LOG_BUILD ON
+)
+set(FPLUS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/thirdparty/fplus/include)
+include_directories(${FPLUS_INCLUDE_DIR})
+
+add_executable(main src/main.cpp)
+add_dependencies(main functional_plus)
+```
+
+
 ### using [cget](https://github.com/pfultz2/cget/)
 
 ```


### PR DESCRIPTION
# Description of this PR
- Add the cmake external project example to the README
- Please let me know if you think it's not appropriate

## Reasons for this PR
- By adding it as an `ExternalProject`, there is no need for users to download and install FunctionalPlus manually
- It allows the build process much easier for end users
- Users still can distribute source codes with the fplus header files included, but there are quite many of them and also it's not clear where these header files come from. 
- Following this way, no actual header file is exposed to the end user because everything will be download during the build process and it's clear these files are downloaded from this GitHub repository.
- I believe this should be the standard way of installing/using FunctionalPlus
- By providing a minimal example of the external project, users can modify it to make it work for their own projects

## Preview of this PR on the README

### using [cmake](https://cmake.org/)
...(skip)...
### using [cmake's ExternalProject](https://cmake.org/cmake/help/v3.0/module/ExternalProject.html)

You can also add `FunctionalPlus` as an `ExternalProject` to your CMakeLists.

The benefits of this:

- No installation
- Better version control by setting the `GIT_TAG`
  - You can always get the latest version by setting it to `master`
  - Or you can get the specific version by setting it to a specific commit point 



```
cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
project(FplusMinimalExternalExample)
set(CMAKE_CXX_STANDARD 14)

include(ExternalProject)
ExternalProject_Add(functional_plus
  GIT_REPOSITORY https://github.com/Dobiasd/FunctionalPlus.git
  GIT_TAG master

  SOURCE_DIR "${CMAKE_BINARY_DIR}/thirdparty/fplus"

  CONFIGURE_COMMAND ""
  BUILD_COMMAND ""
  INSTALL_COMMAND ""

  LOG_DOWNLOAD ON
  LOG_BUILD ON
)
set(FPLUS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/thirdparty/fplus/include)
include_directories(${FPLUS_INCLUDE_DIR})

add_executable(main src/main.cpp)
add_dependencies(main functional_plus)
```


## How to test
- [Setup](#sec-1)
- [Build](#sec-2)


### Setup<a id="sec-1"></a>

Set up projects as follows.

```bash
tree . 
```

    .
    ├── CMakeLists.txt
    └── src
        └── main.cpp
    
    1 directory, 2 files

```bash
cat src/main.cpp
```

    #include <fplus/fplus.hpp>
    #include <iostream>
    
    int main() {
      std::string team = "Our team is great. I love everybody I work with.";
      std::cout << "There actually are this many 'I's in team: "
                << fplus::count("I", fplus::split_words(false, team)) << std::endl;
    }

```bash
cat CMakeLists.txt
```

    cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
    project(FplusExternalExample)
    set(CMAKE_CXX_STANDARD 14)
    
    include(ExternalProject)
    ExternalProject_Add(functional_plus
      GIT_REPOSITORY https://github.com/Dobiasd/FunctionalPlus.git
      GIT_TAG master
    
      SOURCE_DIR "${CMAKE_BINARY_DIR}/thirdparty/fplus"
    
      CONFIGURE_COMMAND ""
      BUILD_COMMAND ""
      INSTALL_COMMAND ""
    
      LOG_DOWNLOAD ON
      LOG_BUILD ON
      )
    set(FPLUS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/thirdparty/fplus/include)
    include_directories(${FPLUS_INCLUDE_DIR})
    
    set(source src/main.cpp)
    add_executable(main ${source})
    add_dependencies(main functional_plus)

### Build<a id="sec-2"></a>

```bash
mkdir build
cd build
cmake ..
make
```

    -- The C compiler identification is AppleClang 8.1.0.8020042
    -- The CXX compiler identification is AppleClang 8.1.0.8020042
    -- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
    -- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Detecting C compile features
    -- Detecting C compile features - done
    -- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
    -- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Configuring done
    -- Generating done
    -- Build files have been written to: /Users/kkweon/temp/fplus-external/build
    Scanning dependencies of target functional_plus
    [ 10%] Creating directories for 'functional_plus'
    [ 20%] Performing download step (git clone) for 'functional_plus'
    -- functional_plus download command succeeded.  See also /Users/kkweon/temp/fplus-external/build/functional_plus-prefix/src/functional_plus-stamp/functional_plus-download-*.log
    [ 30%] No patch step for 'functional_plus'
    [ 40%] Performing update step for 'functional_plus'
    Current branch master is up to date.
    [ 50%] No configure step for 'functional_plus'
    [ 60%] No build step for 'functional_plus'
    [ 70%] No install step for 'functional_plus'
    [ 80%] Completed 'functional_plus'
    [ 80%] Built target functional_plus
    Scanning dependencies of target main
    [ 90%] Building CXX object CMakeFiles/main.dir/src/main.cpp.o
    [100%] Linking CXX executable main
    [100%] Built target main

```bash
./main
```

    There actually are this many 'I's in team: 2
