### PR TITLE
Feature/generic lambdas

### DIFF
--- a/include/fplus/detail/asserts/pairs.hpp
+++ b/include/fplus/detail/asserts/pairs.hpp
@@ -13,12 +13,29 @@ namespace fplus
 {
 namespace detail
 {
+struct apply_to_pair_tag
+{
+};
+
 struct zip_with_tag
 {
 };
 
 struct zip_with_3_tag
 {
+};
+
+template <typename F, typename X, typename Y>
+struct function_traits_asserts<apply_to_pair_tag, F, X, Y>
+{
+    static_assert(utils::function_traits<F>::arity == 2,
+        "Function must take two parameters.");
+    typedef typename utils::function_traits<F>::template arg<0>::type FIn0;
+    typedef typename utils::function_traits<F>::template arg<1>::type FIn1;
+    static_assert(std::is_convertible<X, FIn0>::value,
+        "Function does not take pair.first type as first Parameter.");
+    static_assert(std::is_convertible<Y, FIn1>::value,
+        "Function does not take pair.second type as second Parameter.");
 };
 
 template <typename F, typename X, typename Y>

--- a/include/fplus/detail/asserts/pairs.hpp
+++ b/include/fplus/detail/asserts/pairs.hpp
@@ -1,0 +1,33 @@
+// Copyright 2015, Tobias Hermann and the FunctionalPlus contributors.
+// https://github.com/Dobiasd/FunctionalPlus
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <fplus/detail/function_traits_asserts.hpp>
+#include <fplus/detail/invoke.hpp>
+
+namespace fplus
+{
+namespace detail
+{
+struct zip_with_tag
+{
+};
+
+template <typename F, typename X, typename Y>
+struct function_traits_asserts<zip_with_tag, F, X, Y>
+{
+    static_assert(utils::function_traits<F>::arity == 2,
+        "Function must take two parameters.");
+    typedef typename utils::function_traits<F>::template arg<0>::type FIn0;
+    typedef typename utils::function_traits<F>::template arg<1>::type FIn1;
+    static_assert(std::is_convertible<X, FIn0>::value,
+        "Function does not take elements from first Container as first Parameter.");
+    static_assert(std::is_convertible<Y, FIn1>::value,
+        "Function does not take elements from second Container as second Parameter.");
+};
+}
+}

--- a/include/fplus/detail/asserts/pairs.hpp
+++ b/include/fplus/detail/asserts/pairs.hpp
@@ -25,6 +25,14 @@ struct zip_with_3_tag
 {
 };
 
+struct transform_fst_tag
+{
+};
+
+struct transform_snd_tag
+{
+};
+
 template <typename F, typename X, typename Y>
 struct function_traits_asserts<apply_to_pair_tag, F, X, Y>
 {
@@ -65,6 +73,26 @@ struct function_traits_asserts<zip_with_3_tag, F, X, Y, Z>
         "Function does not take elements from second Container as second Parameter.");
     static_assert(std::is_convertible<Z, FIn2>::value,
         "Function does not take elements from third Container as third Parameter.");
+};
+
+template <typename F, typename X>
+struct function_traits_asserts<transform_fst_tag, F, X>
+{
+    static_assert(utils::function_traits<F>::arity == 1,
+        "Function must take one parameter.");
+    typedef typename utils::function_traits<F>::template arg<0>::type FIn0;
+    static_assert(std::is_convertible<X, FIn0>::value,
+        "Function does not take pair.first type as first Parameter.");
+};
+
+template <typename F, typename X>
+struct function_traits_asserts<transform_snd_tag, F, X>
+{
+    static_assert(utils::function_traits<F>::arity == 1,
+        "Function must take one parameter.");
+    typedef typename utils::function_traits<F>::template arg<0>::type FIn0;
+    static_assert(std::is_convertible<X, FIn0>::value,
+        "Function does not take pair.second type as first Parameter.");
 };
 }
 }

--- a/include/fplus/detail/asserts/pairs.hpp
+++ b/include/fplus/detail/asserts/pairs.hpp
@@ -17,6 +17,10 @@ struct zip_with_tag
 {
 };
 
+struct zip_with_3_tag
+{
+};
+
 template <typename F, typename X, typename Y>
 struct function_traits_asserts<zip_with_tag, F, X, Y>
 {
@@ -28,6 +32,22 @@ struct function_traits_asserts<zip_with_tag, F, X, Y>
         "Function does not take elements from first Container as first Parameter.");
     static_assert(std::is_convertible<Y, FIn1>::value,
         "Function does not take elements from second Container as second Parameter.");
+};
+
+template <typename F, typename X, typename Y, typename Z>
+struct function_traits_asserts<zip_with_3_tag, F, X, Y, Z>
+{
+    static_assert(utils::function_traits<F>::arity == 3,
+        "Function must take two parameters.");
+    typedef typename utils::function_traits<F>::template arg<0>::type FIn0;
+    typedef typename utils::function_traits<F>::template arg<1>::type FIn1;
+    typedef typename utils::function_traits<F>::template arg<2>::type FIn2;
+    static_assert(std::is_convertible<X, FIn0>::value,
+        "Function does not take elements from first Container as first Parameter.");
+    static_assert(std::is_convertible<Y, FIn1>::value,
+        "Function does not take elements from second Container as second Parameter.");
+    static_assert(std::is_convertible<Z, FIn2>::value,
+        "Function does not take elements from third Container as third Parameter.");
 };
 }
 }

--- a/include/fplus/detail/asserts/pairs.hpp
+++ b/include/fplus/detail/asserts/pairs.hpp
@@ -33,6 +33,10 @@ struct transform_snd_tag
 {
 };
 
+struct inner_product_with_tag
+{
+};
+
 template <typename F, typename X, typename Y>
 struct function_traits_asserts<apply_to_pair_tag, F, X, Y>
 {
@@ -93,6 +97,19 @@ struct function_traits_asserts<transform_snd_tag, F, X>
     typedef typename utils::function_traits<F>::template arg<0>::type FIn0;
     static_assert(std::is_convertible<X, FIn0>::value,
         "Function does not take pair.second type as first Parameter.");
+};
+
+template <typename F, typename X, typename Y>
+struct function_traits_asserts<inner_product_with_tag, F, X, Y>
+{
+    static_assert(utils::function_traits<F>::arity == 2,
+        "Function must take two parameters.");
+    typedef typename utils::function_traits<F>::template arg<0>::type FIn0;
+    typedef typename utils::function_traits<F>::template arg<1>::type FIn1;
+    static_assert(std::is_convertible<X, FIn0>::value,
+        "Function does not take elements from first Container as first Parameter.");
+    static_assert(std::is_convertible<Y, FIn1>::value,
+        "Function does not take elements from second Container as second Parameter.");
 };
 }
 }

--- a/include/fplus/pairs.hpp
+++ b/include/fplus/pairs.hpp
@@ -404,14 +404,27 @@ std::vector<std::pair<std::size_t, T>> enumerate(const Container& xs)
 // fwd bind count: 4
 // Calculate the inner product of two sequences using custom operations.
 // inner_product_with((+), (*), [1, 2, 3], [4, 5, 6]) == [32]
-template <typename ContainerIn1, typename ContainerIn2,
-    typename OP1, typename OP2,
-    typename Z,
-    typename OP1In0 = typename utils::function_traits<OP1>::template arg<0>::type,
-    typename OP1In1 = typename utils::function_traits<OP1>::template arg<1>::type,
-    typename TOut = typename std::result_of<OP1(OP1In0, OP1In1)>::type>
-TOut inner_product_with(OP1 op1, OP2 op2, const Z& value,
-        const ContainerIn1& xs, const ContainerIn2& ys)
+template <
+    typename ContainerIn1,
+    typename ContainerIn2,
+    typename OP1,
+    typename OP2,
+    typename Acc,
+    typename X = typename ContainerIn1::value_type,
+    typename Y = typename ContainerIn2::value_type,
+    bool = detail::
+        trigger_static_asserts<detail::inner_product_with_tag, OP2, X, Y>(),
+    typename OP2Out = detail::invoke_result_t<OP2, X, Y>,
+    bool = detail::trigger_static_asserts<detail::inner_product_with_tag,
+                                          OP1,
+                                          Acc,
+                                          OP2Out>(),
+    typename TOut = std::decay_t<detail::invoke_result_t<OP1, Acc, OP2Out>>>
+TOut inner_product_with(OP1 op1,
+                        OP2 op2,
+                        const Acc& value,
+                        const ContainerIn1& xs,
+                        const ContainerIn2& ys)
 {
     assert(size_of_cont(xs) == size_of_cont(ys));
     return std::inner_product(

--- a/include/fplus/pairs.hpp
+++ b/include/fplus/pairs.hpp
@@ -215,22 +215,30 @@ Y snd(const std::pair<X, Y>& pair)
 // fwd bind count: 1
 // Apply a function to the first element of a pair.
 // transform_fst(square, (4, 5)) == (16, 5)
-template <typename X, typename Y, typename F,
-    typename ResultFirst = typename std::result_of<F(X)>::type>
+template <
+    typename X,
+    typename Y,
+    typename F,
+    bool = detail::trigger_static_asserts<detail::transform_fst_tag, F, X>(),
+    typename ResultFirst = std::decay_t<detail::invoke_result_t<F, X>>>
 std::pair<ResultFirst, Y> transform_fst(F f, const std::pair<X, Y>& pair)
 {
-    return std::make_pair(f(pair.first), pair.second);
+    return std::make_pair(detail::invoke(f, pair.first), pair.second);
 }
 
 // API search type: transform_snd : ((b -> c), (a, b)) -> (a, c)
 // fwd bind count: 1
 // Apply a function to the second element of a pair.
 // transform_snd(square, (4, 5)) == (4, 25)
-template <typename X, typename Y, typename F,
-    typename ResultSecond = typename std::result_of<F(Y)>::type>
+template <
+    typename X,
+    typename Y,
+    typename F,
+    bool = detail::trigger_static_asserts<detail::transform_snd_tag, F, Y>(),
+    typename ResultSecond = std::decay_t<detail::invoke_result_t<F, Y>>>
 std::pair<X, ResultSecond> transform_snd(F f, const std::pair<X, Y>& pair)
 {
-    return std::make_pair(pair.first, f(pair.second));
+    return std::make_pair(pair.first, detail::invoke(f, pair.second));
 }
 
 // API search type: transform_pair : ((a -> c), (b -> d), (a, b)) -> (c, d)

--- a/include/fplus/pairs.hpp
+++ b/include/fplus/pairs.hpp
@@ -59,7 +59,7 @@ template <typename ContainerIn1,
           typename X = typename ContainerIn1::value_type,
           typename Y = typename ContainerIn2::value_type,
           bool = detail::trigger_static_asserts<detail::zip_with_tag, F, X, Y>(),
-          typename TOut = detail::invoke_result_t<F, X, Y>,
+          typename TOut = std::decay_t<detail::invoke_result_t<F, X, Y>>,
           typename ContainerOut = std::vector<TOut>>
 ContainerOut zip_with(F f, const ContainerIn1& xs, const ContainerIn2& ys)
 {

--- a/include/fplus/pairs.hpp
+++ b/include/fplus/pairs.hpp
@@ -18,14 +18,16 @@ namespace fplus
 // API search type: apply_to_pair : (((a, b) -> c), (a, b)) -> c
 // fwd bind count: 1
 // Apply binary function to parts of a pair.
-template <typename F,
-    typename FIn0 = typename utils::function_traits<F>::template arg<0>::type,
-    typename FIn1 = typename utils::function_traits<F>::template arg<1>::type,
-    typename FOut = typename std::result_of<F(FIn0, FIn1)>::type>
+template <
+    typename F,
+    typename FIn0,
+    typename FIn1,
+    bool = detail::
+        trigger_static_asserts<detail::apply_to_pair_tag, F, FIn0, FIn1>(),
+    typename FOut = std::decay_t<detail::invoke_result_t<F, FIn0, FIn1>>>
 FOut apply_to_pair(F f, const std::pair<FIn0, FIn1>& p)
 {
-    internal::check_arity<2, F>();
-    return f(p.first, p.second);
+    return detail::invoke(f, p.first, p.second);
 }
 
 // API search type: zip_with : (((a, b) -> c), [a], [b]) -> [c]

--- a/include/fplus/pairs.hpp
+++ b/include/fplus/pairs.hpp
@@ -245,13 +245,21 @@ std::pair<X, ResultSecond> transform_snd(F f, const std::pair<X, Y>& pair)
 // fwd bind count: 2
 // Apply functions the both parts of a pair.
 // transform_pair(square, square, (4, 5)) == (16, 25)
-template <typename X, typename Y, typename F, typename G,
-    typename ResultFirst = typename std::result_of<F(X)>::type,
-    typename ResultSecond = typename std::result_of<G(Y)>::type>
-std::pair<ResultFirst, ResultSecond> transform_pair(
-    F f, G g, const std::pair<X, Y>& pair)
+template <
+    typename X,
+    typename Y,
+    typename F,
+    typename G,
+    bool = detail::trigger_static_asserts<detail::transform_fst_tag, F, X>(),
+    bool = detail::trigger_static_asserts<detail::transform_snd_tag, G, Y>(),
+    typename ResultFirst = std::decay_t<detail::invoke_result_t<F, X>>,
+    typename ResultSecond = std::decay_t<detail::invoke_result_t<G, Y>>>
+std::pair<ResultFirst, ResultSecond> transform_pair(F f,
+                                                    G g,
+                                                    const std::pair<X, Y>& pair)
 {
-    return std::make_pair(f(pair.first), g(pair.second));
+    return std::make_pair(detail::invoke(f, pair.first),
+                          detail::invoke(g, pair.second));
 }
 
 // API search type: swap_pair_elems : (a, b) -> (b, a)

--- a/include/fplus/pairs.hpp
+++ b/include/fplus/pairs.hpp
@@ -115,14 +115,20 @@ ContainerOut zip_with_3(F f,
 // and extrapolate the shorter sequence with a default value.
 // zip_with_defaults((+), 6, 7, [1,2,3], [1,2]) == [2,4,10]
 // zip_with_defaults((+), 6, 7, [1,2], [1,2,3]) == [2,4,9]
-template <typename ContainerIn1, typename ContainerIn2, typename F,
+template <
+    typename ContainerIn1,
+    typename ContainerIn2,
+    typename F,
     typename X = typename ContainerIn1::value_type,
     typename Y = typename ContainerIn2::value_type,
-    typename TOut = typename std::result_of<F(X, Y)>::type,
+    bool = detail::trigger_static_asserts<detail::zip_with_tag, F, X, Y>(),
+    typename TOut = std::decay_t<detail::invoke_result_t<F, X, Y>>,
     typename ContainerOut = typename std::vector<TOut>>
 ContainerOut zip_with_defaults(F f,
-        const X& default_x, const Y& default_y,
-        const ContainerIn1& xs, const ContainerIn2& ys)
+                               const X& default_x,
+                               const Y& default_y,
+                               const ContainerIn1& xs,
+                               const ContainerIn2& ys)
 {
     const auto size_xs = size_of_cont(xs);
     const auto size_ys = size_of_cont(ys);

--- a/include/fplus/pairs.hpp
+++ b/include/fplus/pairs.hpp
@@ -9,33 +9,12 @@
 #include <fplus/container_common.hpp>
 #include <fplus/function_traits.hpp>
 #include <fplus/detail/invoke.hpp>
-#include <fplus/detail/function_traits_asserts.hpp>
+#include <fplus/detail/asserts/pairs.hpp>
 
 #include <utility>
 
 namespace fplus
 {
-namespace detail
-{
-struct zip_with_tag
-{
-};
-
-template <typename F, typename X, typename Y>
-struct function_traits_asserts<zip_with_tag, F, X, Y>
-{
-    static_assert(utils::function_traits<F>::arity == 2,
-        "Function must take two parameters.");
-    using FOut = invoke_result_t<F, X, Y>;
-    typedef typename utils::function_traits<F>::template arg<0>::type FIn0;
-    typedef typename utils::function_traits<F>::template arg<1>::type FIn1;
-    static_assert(std::is_convertible<X, FIn0>::value,
-        "Function does not take elements from first Container as first Parameter.");
-    static_assert(std::is_convertible<Y, FIn1>::value,
-        "Function does not take elements from second Container as second Parameter.");
-};
-}
-
 // API search type: apply_to_pair : (((a, b) -> c), (a, b)) -> c
 // fwd bind count: 1
 // Apply binary function to parts of a pair.
@@ -63,10 +42,6 @@ template <typename ContainerIn1,
           typename ContainerOut = std::vector<TOut>>
 ContainerOut zip_with(F f, const ContainerIn1& xs, const ContainerIn2& ys)
 {
-  using FOut = detail::invoke_result_t<F, X, Y>;
-  static_assert(
-      std::is_convertible<FOut, TOut>::value,
-      "Elements produced by this function can not be stored in ContainerOut.");
   static_assert(
       std::is_same<
           typename internal::same_cont_new_t<ContainerIn1, void>::type,
@@ -80,7 +55,7 @@ ContainerOut zip_with(F f, const ContainerIn1& xs, const ContainerIn2& ys)
   auto itYs = std::begin(ys);
   for (std::size_t i = 0; i < resultSize; ++i)
   {
-    *itResult = f(*itXs, *itYs);
+    *itResult = detail::invoke(f, *itXs, *itYs);
     ++itXs;
     ++itYs;
   }

--- a/include/fplus/pairs.hpp
+++ b/include/fplus/pairs.hpp
@@ -66,33 +66,22 @@ ContainerOut zip_with(F f, const ContainerIn1& xs, const ContainerIn2& ys)
 // fwd bind count: 3
 // Zip three sequences using a ternary function.
 // zip_with_3((+), [1, 2, 3], [5, 6], [1, 1]) == [7, 9]
-template <typename ContainerIn1, typename ContainerIn2, typename ContainerIn3,
+template <
+    typename ContainerIn1,
+    typename ContainerIn2,
+    typename ContainerIn3,
     typename F,
     typename X = typename ContainerIn1::value_type,
     typename Y = typename ContainerIn2::value_type,
     typename Z = typename ContainerIn3::value_type,
-    typename TOut = typename std::result_of<F(X, Y, Z)>::type,
+    bool = detail::trigger_static_asserts<detail::zip_with_3_tag, F, X, Y, Z>(),
+    typename TOut = std::decay_t<detail::invoke_result_t<F, X, Y, Z>>,
     typename ContainerOut = typename std::vector<TOut>>
 ContainerOut zip_with_3(F f,
-    const ContainerIn1& xs, const ContainerIn2& ys, const ContainerIn3& zs)
+                        const ContainerIn1& xs,
+                        const ContainerIn2& ys,
+                        const ContainerIn3& zs)
 {
-    static_assert(utils::function_traits<F>::arity == 3,
-        "Function must take two parameters.");
-    typedef typename std::result_of<F(X, Y, Z)>::type FOut;
-    typedef typename utils::function_traits<F>::template arg<0>::type FIn0;
-    typedef typename utils::function_traits<F>::template arg<1>::type FIn1;
-    typedef typename utils::function_traits<F>::template arg<2>::type FIn2;
-    typedef typename ContainerIn1::value_type T1;
-    typedef typename ContainerIn2::value_type T2;
-    typedef typename ContainerIn3::value_type T3;
-    static_assert(std::is_convertible<T1, FIn0>::value,
-        "Function does not take elements from first Container as first Parameter.");
-    static_assert(std::is_convertible<T2, FIn1>::value,
-        "Function does not take elements from second Container as second Parameter.");
-    static_assert(std::is_convertible<T3, FIn2>::value,
-        "Function does not take elements from third Container as third Parameter.");
-    static_assert(std::is_convertible<FOut, TOut>::value,
-        "Elements produced by this function can not be stored in ContainerOut.");
     static_assert(std::is_same<
         typename internal::same_cont_new_t<ContainerIn1, void>::type,
         typename internal::same_cont_new_t<ContainerIn2, void>::type>::value,
@@ -110,7 +99,7 @@ ContainerOut zip_with_3(F f,
     auto itZs = std::begin(zs);
     for (std::size_t i = 0; i < resultSize; ++i)
     {
-        *itResult = f(*itXs, *itYs, *itZs);
+        *itResult = detail::invoke(f, *itXs, *itYs, *itZs);
         ++itXs;
         ++itYs;
         ++itZs;

--- a/test/composition_test.cpp
+++ b/test/composition_test.cpp
@@ -130,7 +130,9 @@ TEST_CASE("composition_test, apply_to_pair")
 {
     using namespace fplus;
     auto APlusTwoTimesB = [](int a, int b) { return a + 2 * b; };
+    auto APlusTwoTimesBGenericLambda = [](auto a, auto b) { return a + 2 * b; };
     REQUIRE_EQ((apply_to_pair(APlusTwoTimesB, std::make_pair(1, 2))), 5);
+    REQUIRE_EQ((apply_to_pair(APlusTwoTimesBGenericLambda, std::make_pair(1, 2))), 5);
     REQUIRE_EQ((apply_to_pair(APlusTwoTimesBFunc, std::make_pair(1, 2))), 5);
 }
 

--- a/test/generate_test.cpp
+++ b/test/generate_test.cpp
@@ -362,6 +362,7 @@ TEST_CASE("generate_test, inner_product")
     const auto mult = [](int x, int y) { return x * y; };
     REQUIRE_EQ(fplus::inner_product(0, xs, ys), 32);
     REQUIRE_EQ(fplus::inner_product_with(plus, mult, 0, xs, ys), 32);
+    REQUIRE_EQ(fplus::inner_product_with(std::plus<>{}, std::multiplies<>{}, 0, xs, ys), 32);
 }
 
 TEST_CASE("generate_test, numbers")

--- a/test/pairs_test.cpp
+++ b/test/pairs_test.cpp
@@ -45,8 +45,10 @@ TEST_CASE("pairs_test, zip_with_defaults")
 {
     using namespace fplus;
     const auto add = [](int x, int y){ return x + y; };
+    const auto add_generic = [](auto x, auto y){ return x + y; };
     REQUIRE_EQ(zip_with_defaults(add, 6, 7, IntVector({1,2,3}), IntVector({1,2})), IntVector({2,4,10}));
     REQUIRE_EQ(zip_with_defaults(add, 6, 7, IntVector({1,2}), IntVector({1,2,3})), IntVector({2,4,9}));
+    REQUIRE_EQ(zip_with_defaults(add_generic, 6, 7, IntVector({1,2}), IntVector({1,2,3})), IntVector({2,4,9}));
 }
 
 TEST_CASE("pairs_test, zip")

--- a/test/pairs_test.cpp
+++ b/test/pairs_test.cpp
@@ -70,6 +70,8 @@ TEST_CASE("pairs_test, pair functions")
     REQUIRE_EQ(swap_pairs_elems(intPairs), intPairsSwapped);
     REQUIRE_EQ(transform_fst(squareLambda, intPair), std::make_pair(4, 3));
     REQUIRE_EQ(transform_snd(squareLambda, intPair), std::make_pair(2, 9));
+    REQUIRE_EQ(transform_fst([](auto i) { return i * i; }, intPair), std::make_pair(4, 3));
+    REQUIRE_EQ(transform_snd([](auto i) { return i * i; }, intPair), std::make_pair(2, 9));
 
     typedef std::vector<std::pair<std::string, int>> StringIntPairs;
     StringIntPairs stringIntPairs = {{"a", 1}, {"a", 2}, {"b", 6}, {"a", 4}};

--- a/test/pairs_test.cpp
+++ b/test/pairs_test.cpp
@@ -15,6 +15,11 @@ namespace {
     typedef std::pair<int, int> IntPair;
     typedef std::vector<IntPair> IntPairs;
     IntVector xs = {1,2,2,3,2};
+
+    struct dummy
+    {
+      int i;
+    };
 }
 
 TEST_CASE("pairs_test, zip_with")
@@ -72,6 +77,7 @@ TEST_CASE("pairs_test, pair functions")
     REQUIRE_EQ(transform_snd(squareLambda, intPair), std::make_pair(2, 9));
     REQUIRE_EQ(transform_fst([](auto i) { return i * i; }, intPair), std::make_pair(4, 3));
     REQUIRE_EQ(transform_snd([](auto i) { return i * i; }, intPair), std::make_pair(2, 9));
+    REQUIRE_EQ(transform_pair(squareLambda, squareLambda, intPair), std::make_pair(4, 9));
 
     typedef std::vector<std::pair<std::string, int>> StringIntPairs;
     StringIntPairs stringIntPairs = {{"a", 1}, {"a", 2}, {"b", 6}, {"a", 4}};
@@ -82,6 +88,16 @@ TEST_CASE("pairs_test, pair functions")
     auto groupMendianValues = transform(getMedianValue, groupNames);
     auto stringIntPairsSndReplacedWithGroupMedian = zip(groupNames, groupMendianValues);
     REQUIRE_EQ(stringIntPairsSndReplacedWithGroupMedian, StringIntPairs({{"a", 2}, {"a", 2}, {"b", 6}, {"a", 2}}));
+
+    // Thanks to invoke, such code works.
+    // (I don't have a use case for it though)
+    dummy dumb;
+    dumb.i = 42;
+
+    auto p = std::make_pair(dumb, dumb);
+    auto result = transform_pair(&dummy::i, &dummy::i, p);
+    REQUIRE_EQ(result, std::make_pair(42, 42));
+
 }
 
 TEST_CASE("pairs_test, enumerate")

--- a/test/pairs_test.cpp
+++ b/test/pairs_test.cpp
@@ -35,7 +35,10 @@ TEST_CASE("pairs_test, zip_with_3")
 {
     using namespace fplus;
     const auto multiply = [](int x, int y, int z){ return x * y * z; };
-    REQUIRE_EQ(zip_with_3(multiply, xs, xs, xs), transform(cubeLambda, xs));
+    const auto multiply_generic = [](auto x, auto y, auto z){ return x * y * z; };
+    const auto cubed = transform(cubeLambda, xs);
+    REQUIRE_EQ(zip_with_3(multiply, xs, xs, xs), cubed);
+    REQUIRE_EQ(zip_with_3(multiply_generic, xs, xs, xs), cubed);
 }
 
 TEST_CASE("pairs_test, zip_with_defaults")

--- a/test/pairs_test.cpp
+++ b/test/pairs_test.cpp
@@ -26,13 +26,9 @@ TEST_CASE("pairs_test, zip_with")
     REQUIRE_EQ(zip_with(add, IntVector({1,2,3}), IntVector({1,2})), IntVector({2,4}));
     REQUIRE_EQ(zip_with(add, IntVector({1,2}), IntVector({1,2,3})), IntVector({2,4}));
 
-    // uncomment to see static_asserts
-    // zip_with([](auto a, auto b, auto c) { return a + b; },
-    //          IntVector({1, 2, 3}),
-    //          IntVector({1, 2, 3}));
-    // zip_with([](int a, int b, int c) { return a + b; },
-    //          IntVector({1, 2, 3}),
-    //          IntVector({1, 2, 3}));
+    const auto add_generic = [](auto x, int y) {return x + y;};
+    REQUIRE_EQ(zip_with(add_generic, IntVector({1,2,3}), IntVector({1,2})), IntVector({2,4}));
+    REQUIRE_EQ(zip_with(std::plus<>{}, IntVector({1,2,3}), IntVector({1,2})), IntVector({2,4}));
 }
 
 TEST_CASE("pairs_test, zip_with_3")


### PR DESCRIPTION
Hi, I started to convert some functions in `pairs.hpp` to be generic-lambda compatible.

I think we should split the work in small parts, there's a lot to do.

First, I believe we should add a tag for each method as I did in `detail/asserts/pais.hpp`, and once we finish it will be easier to spot code duplication.

In the end we will have a `binary_predicate_tag` and so on.

Next time I will tackle `compare.hpp`, `equal_by` is needed for `match/mismatch` functions in `pairs.hpp`.