### PR TITLE
Clang 5.0 Builds and some related fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,13 @@ matrix:
           sources: &sources
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise
-            - llvm-toolchain-precise-3.9
             - llvm-toolchain-precise-3.8
             - llvm-toolchain-precise-3.7
             - llvm-toolchain-precise-3.6
-            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
-              key_url: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
+            - llvm-toolchain-trusty
+            - llvm-toolchain-trusty-3.9
+            - llvm-toolchain-trusty-4.0
+            - llvm-toolchain-trusty-5.0
     - env: CXX=g++-6 CC=gcc-6
       addons:
         apt:
@@ -36,6 +37,13 @@ matrix:
         apt:
           packages:
             - g++-4.9
+          sources: *sources
+    - env: CXX=clang++-5.0 CC=clang-5.0
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+            - libc++-dev
           sources: *sources
     - env: CXX=clang++-4.0 CC=clang-4.0
       addons:

--- a/test/pairs_test.cpp
+++ b/test/pairs_test.cpp
@@ -91,7 +91,6 @@ TEST_CASE("pairs_test, pair functions")
     const std::function<int(int)> double_int = [](int x) -> int {
       return 2 * x;
     };
-    typedef std::pair<int, int> IntPair;
     REQUIRE_EQ(transform_pair(double_int, double_int, IntPair({2, 3})),
         IntPair({4, 6}));
 

--- a/test/transform_test.cpp
+++ b/test/transform_test.cpp
@@ -32,7 +32,6 @@ TEST_CASE("transform_test, replicate_elems")
 TEST_CASE("transform_test, interleave")
 {
     using namespace fplus;
-    typedef std::vector<IntVector> IntVectors;
     REQUIRE_EQ(interleave(IntVectors()), IntVector());
     REQUIRE_EQ(interleave(IntVectors({})), IntVector());
     REQUIRE_EQ(interleave(IntVectors({IntVector({})})), IntVector());
@@ -45,7 +44,6 @@ TEST_CASE("transform_test, interleave")
 TEST_CASE("transform_test, transpose")
 {
     using namespace fplus;
-    typedef std::vector<IntVector> IntVectors;
     REQUIRE_EQ(transpose(IntVectors()), IntVectors());
     REQUIRE_EQ(transpose(IntVectors({})), IntVectors());
     REQUIRE_EQ(transpose(IntVectors({},{})), IntVectors());


### PR DESCRIPTION
Clang 5.0 has been released and is already available on Travis. This PR adds a build using the latest clang and fixes two shadowing warnings reported by it.