### PR TITLE
add relocatable cmake generated pkgconfig installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ before_install:
 
 install:
   - mkdir -p build && cd build
-  - cmake .. -DUNITTEST=ON
+  - cmake .. -DFPLUS_BUILD_UNITTEST=ON
 
 script:
   - which $CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,56 +1,128 @@
 cmake_minimum_required(VERSION 3.2)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+
 project(FunctionalPlus VERSION 0.2)
 
 message(STATUS "===( ${PROJECT_NAME} ${PROJECT_VERSION} )===")
 
-option(UNITTEST "Build unit tests" OFF)
+option(FPLUS_USE_TOOLCHAIN "Use compiler flags from an external toolchain" OFF)
+option(FPLUS_BUILD_EXAMPLES "Build examples" ON)
+option(FPLUS_BUILD_UNITTEST "Build unit tests" ON)
 message(STATUS "Building Unit Tests ${UNITTEST}")
 
+if(NOT FPLUS_USE_TOOLCHAIN)
+  set(COMPILE_OPTIONS -Wall
+    -Wextra
+    -pedantic
+    -Werror
+    -Weffc++
+    -Wconversion
+    -Wsign-conversion
+    -Wctor-dtor-privacy
+    -Wreorder
+    -Wold-style-cast
+    -Wparentheses
+    )
 
-set(COMPILE_OPTIONS -Wall
-                    -Wextra
-                    -pedantic
-                    -Werror
-                    -Weffc++
-                    -Wconversion
-                    -Wsign-conversion
-                    -Wctor-dtor-privacy
-                    -Wreorder
-                    -Wold-style-cast
-                    -Wparentheses
-                    )
-
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-
-find_package(Threads REQUIRED)
-
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
 
 add_library(fplus INTERFACE)
 target_include_directories(fplus INTERFACE
-                       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                       $<INSTALL_INTERFACE:include>
-                        )
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+  )
 
-if( UNITTEST )
+find_package(Threads REQUIRED)
+target_link_libraries(fplus INTERFACE Threads::Threads)
+
+if(FPLUS_BUILD_UNITTEST)
     enable_testing()
     add_subdirectory(test)
 endif()
 
-add_executable(readme_perf_examples EXCLUDE_FROM_ALL examples/readme_perf_examples.cpp)
-target_compile_options(readme_perf_examples PRIVATE ${COMPILE_OPTIONS})
-target_link_libraries(readme_perf_examples PRIVATE fplus ${CMAKE_THREAD_LIBS_INIT})
+if(FPLUS_BUILD_EXAMPLES)
+    add_executable(readme_perf_examples EXCLUDE_FROM_ALL examples/readme_perf_examples.cpp)
+    target_compile_options(readme_perf_examples PRIVATE ${COMPILE_OPTIONS})
+    target_link_libraries(readme_perf_examples PRIVATE fplus ${CMAKE_THREAD_LIBS_INIT})
 
-add_executable(99_problems EXCLUDE_FROM_ALL examples/99_problems.cpp)
-target_compile_options(99_problems PRIVATE ${COMPILE_OPTIONS})
-target_link_libraries(99_problems PRIVATE fplus ${CMAKE_THREAD_LIBS_INIT})
+    add_executable(99_problems EXCLUDE_FROM_ALL examples/99_problems.cpp)
+    target_compile_options(99_problems PRIVATE ${COMPILE_OPTIONS})
+    target_link_libraries(99_problems PRIVATE fplus ${CMAKE_THREAD_LIBS_INIT})
+endif()
 
+# Installation (https://github.com/forexample/package-example) {
 
-install(TARGETS fplus EXPORT fplus-config DESTINATION include)
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/include/" DESTINATION include)
-install(EXPORT fplus-config DESTINATION share/fplus/cmake)
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
 
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Use:
+#   * PROJECT_VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+# Targets:
+#   * header location after install: <prefix>/include/fplus/fplus.hpp
+#   * headers can be included by C++ code `#include <fplus/fplus.hpp>`
+install(
+    TARGETS fplus
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    RUNTIME DESTINATION "bin"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+# Headers:
+#   * include/fplus/fplus.hpp -> <prefix>/include/fplus/fplus.hpp
+install(
+    DIRECTORY "include/fplus" # no trailing slash
+    DESTINATION "${include_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/FunctionalPlus/FunctionalPlusConfig.cmake
+#   * <prefix>/lib/cmake/FunctionalPlus/FunctionalPlusConfigVersion.cmake
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/FunctionalPlus/FunctionalPlusTargets.cmake
+install(
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)
+
+# }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,25 +9,11 @@ message(STATUS "===( ${PROJECT_NAME} ${PROJECT_VERSION} )===")
 option(FPLUS_USE_TOOLCHAIN "Use compiler flags from an external toolchain" OFF)
 option(FPLUS_BUILD_EXAMPLES "Build examples" ON)
 option(FPLUS_BUILD_UNITTEST "Build unit tests" ON)
-message(STATUS "Building Unit Tests ${UNITTEST}")
+message(STATUS "Building Unit Tests ${FPLUS_BUILD_UNITTEST}")
+message(STATUS "Building examples ${FPLUS_BUILD_EXAMPLES}")
 
 if(NOT FPLUS_USE_TOOLCHAIN)
-  set(COMPILE_OPTIONS -Wall
-    -Wextra
-    -pedantic
-    -Werror
-    -Weffc++
-    -Wconversion
-    -Wsign-conversion
-    -Wctor-dtor-privacy
-    -Wreorder
-    -Wold-style-cast
-    -Wparentheses
-    )
-
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
+  include(cmake/toolchain.cmake)
 endif()
 
 add_library(fplus INTERFACE)
@@ -53,76 +39,5 @@ if(FPLUS_BUILD_EXAMPLES)
     target_link_libraries(99_problems PRIVATE fplus ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
-# Installation (https://github.com/forexample/package-example) {
-
-# Layout. This works for all platforms:
-#   * <prefix>/lib/cmake/<PROJECT-NAME>
-#   * <prefix>/lib/
-#   * <prefix>/include/
-set(config_install_dir "lib/cmake/${PROJECT_NAME}")
-set(include_install_dir "include")
-
-set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
-
-# Configuration
-set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
-set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
-set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-set(namespace "${PROJECT_NAME}::")
-
-# Include module with fuction 'write_basic_package_version_file'
-include(CMakePackageConfigHelpers)
-
-# Configure '<PROJECT-NAME>ConfigVersion.cmake'
-# Use:
-#   * PROJECT_VERSION
-write_basic_package_version_file(
-    "${version_config}" COMPATIBILITY SameMajorVersion
-)
-
-# Configure '<PROJECT-NAME>Config.cmake'
-# Use variables:
-#   * TARGETS_EXPORT_NAME
-#   * PROJECT_NAME
-configure_package_config_file(
-    "cmake/Config.cmake.in"
-    "${project_config}"
-    INSTALL_DESTINATION "${config_install_dir}"
-)
-
-# Targets:
-#   * header location after install: <prefix>/include/fplus/fplus.hpp
-#   * headers can be included by C++ code `#include <fplus/fplus.hpp>`
-install(
-    TARGETS fplus
-    EXPORT "${TARGETS_EXPORT_NAME}"
-    LIBRARY DESTINATION "lib"
-    ARCHIVE DESTINATION "lib"
-    RUNTIME DESTINATION "bin"
-    INCLUDES DESTINATION "${include_install_dir}"
-)
-
-# Headers:
-#   * include/fplus/fplus.hpp -> <prefix>/include/fplus/fplus.hpp
-install(
-    DIRECTORY "include/fplus" # no trailing slash
-    DESTINATION "${include_install_dir}"
-)
-
-# Config
-#   * <prefix>/lib/cmake/FunctionalPlus/FunctionalPlusConfig.cmake
-#   * <prefix>/lib/cmake/FunctionalPlus/FunctionalPlusConfigVersion.cmake
-install(
-    FILES "${project_config}" "${version_config}"
-    DESTINATION "${config_install_dir}"
-)
-
-# Config
-#   * <prefix>/lib/cmake/FunctionalPlus/FunctionalPlusTargets.cmake
-install(
-    EXPORT "${TARGETS_EXPORT_NAME}"
-    NAMESPACE "${namespace}"
-    DESTINATION "${config_install_dir}"
-)
-
-# }
+# Run pkgconfig installation:
+include(cmake/pkgconfig.cmake)

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ sudo localedef -c -i ru_RU -f CP1251 ru_RU.CP1251
 sudo localedef -c -i el_GR -f CP1253 el_GR.CP1253
 
 # enable, build and run unittests
-cmake -DUNITTEST=ON ..
+cmake -DFPLUS_BUILD_UNITTEST=ON ..
 make unittest
 ```
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+find_package(Threads REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/cmake/pkgconfig.cmake
+++ b/cmake/pkgconfig.cmake
@@ -1,0 +1,73 @@
+# Installation (https://github.com/forexample/package-example) {
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Use:
+#   * PROJECT_VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+# Targets:
+#   * header location after install: <prefix>/include/fplus/fplus.hpp
+#   * headers can be included by C++ code `#include <fplus/fplus.hpp>`
+install(
+    TARGETS fplus
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    RUNTIME DESTINATION "bin"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+# Headers:
+#   * include/fplus/fplus.hpp -> <prefix>/include/fplus/fplus.hpp
+install(
+    DIRECTORY "include/fplus" # no trailing slash
+    DESTINATION "${include_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/FunctionalPlus/FunctionalPlusConfig.cmake
+#   * <prefix>/lib/cmake/FunctionalPlus/FunctionalPlusConfigVersion.cmake
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/FunctionalPlus/FunctionalPlusTargets.cmake
+install(
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)
+
+# }

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -1,0 +1,16 @@
+set(COMPILE_OPTIONS -Wall
+  -Wextra
+  -pedantic
+  -Werror
+  -Weffc++
+  -Wconversion
+  -Wsign-conversion
+  -Wctor-dtor-privacy
+  -Wreorder
+  -Wold-style-cast
+  -Wparentheses
+  )
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
... and related changes.

* rename UNITTEST option to FPLUS_BUILD_UNITTEST to avoid name collisions with direct`add_subdirectory()` usage
* add FPLUS_BUILD_{EXAMPLES,UNITTEST} option to support cmake pkconfig build + installation without the tests and examples (default ON based on previous behavior)
* add FPLUS_USE_TOOLCHAIN to allow the user to provide their own toolchain definitions (higher language standard or warnings), which is friendly to package managers (default OFF to mirror current behavior)
* remove `$<INSTALL_INTERFACE:include>` from target_include_diretories (not required)
* use list APPEND for CMAKE_MODULE_PATH to avoid clobbering existing CMAKE_MODULE_PATH definition, and prefer CMAKE_CURRENT_LIST_DIR to CMAKE_CURRENT_SOURCE_DIR
* add INTERFACE linking of Threads::Threads to lib, and include in pkgconfig dependencies
* add cmake generated relocatable pkgconfig installation (CONFIG mode FunctionalPlus package with fplus INTERFACE library) using tested boilerplate from https://github.com/forexample/package-example (application of https://cmake.org/cmake/help/v3.10/module/CMakePackageConfigHelpers.html)

The installed package supports use of FunctionalPlus with syntax like this:

```
find_package(FunctionalPlus CONFIG REQUIRED)

add_executable(foo foo.cpp)
target_link_libraries(foo FunctionalPlus::fplus)
```

NOTE: This enables pkgconfig usage of frugally-deep.