### PR TITLE
Clang 6 build fixed

### DIFF
--- a/cmake/install_libcxx.sh
+++ b/cmake/install_libcxx.sh
@@ -2,7 +2,7 @@
 
 # source: https://github.com/ericniebler/range-v3
 
-TRUNK_VERSION="5.*"
+TRUNK_VERSION="6.*"
 
 set -e
 


### PR DESCRIPTION
The current Clang 6 is broken due a failing libc++ installation. The download fails because the version of the compiler is used for the filename (that is 6.0.1) which is not available.

Using v6 as trunk version fixes the problem.