### PR TITLE
update `append`, add `transform_append`

### DIFF
--- a/include/fplus/container_common.hpp
+++ b/include/fplus/container_common.hpp
@@ -1130,16 +1130,27 @@ ContainerOut prepend_elem(const T& y, Container&& xs)
 // fwd bind count: 1
 // Concatenaes two sequences.
 // append([1, 2], [3, 4, 5]) == [1, 2, 3, 4, 5]
-template <typename Container>
-Container append(const Container& xs, const Container& ys)
+template <typename ContainerIn1, typename ContainerIn2 = ContainerIn1, typename ContainerOut = ContainerIn1>
+ContainerOut append(const ContainerIn1& xs, const ContainerIn2& ys)
 {
-    Container result;
+    ContainerOut result;
     internal::prepare_container(result, size_of_cont(xs) + size_of_cont(ys));
     std::copy(std::begin(xs), std::end(xs),
         internal::get_back_inserter(result));
     std::copy(std::begin(ys), std::end(ys),
         internal::get_back_inserter(result));
     return result;
+}
+
+
+// API search type: transform_append : ([a], [a]) -> [a]
+// fwd bind count: 1
+// Same as append, but makes it easy to
+// use an output container type different from the input container type.
+template <typename ContainerOut, typename ContainerIn1, typename ContainerIn2 = ContainerIn1>
+ContainerOut transform_append(const ContainerIn1& xs, const ContainerIn2& ys)
+{
+    return append<ContainerIn1, ContainerIn2, ContainerOut>(xs, ys);
 }
 
 // API search type: concat : [[a]] -> [a]

--- a/include/fplus/container_common.hpp
+++ b/include/fplus/container_common.hpp
@@ -1143,12 +1143,12 @@ ContainerOut append(const ContainerIn1& xs, const ContainerIn2& ys)
 }
 
 
-// API search type: transform_append : ([a], [a]) -> [a]
+// API search type: append_convert : ([a], [a]) -> [a]
 // fwd bind count: 1
-// Same as append, but makes it easy to
+// Same as append, but makes it easier to
 // use an output container type different from the input container type.
 template <typename ContainerOut, typename ContainerIn1, typename ContainerIn2 = ContainerIn1>
-ContainerOut transform_append(const ContainerIn1& xs, const ContainerIn2& ys)
+ContainerOut append_convert(const ContainerIn1& xs, const ContainerIn2& ys)
 {
     return append<ContainerIn1, ContainerIn2, ContainerOut>(xs, ys);
 }

--- a/test/container_common_test.cpp
+++ b/test/container_common_test.cpp
@@ -199,11 +199,11 @@ TEST_CASE("container_common_test, append")
     REQUIRE_EQ(append(xs, xs_empty), xs);
 }
 
-TEST_CASE("container_common_test, transform_append")
+TEST_CASE("container_common_test, append_convert")
 {
     using namespace fplus;
-    REQUIRE_EQ(transform_append<decltype(xs2Times)>(xs_arr, xs_arr), xs2Times);
-    REQUIRE_EQ(transform_append<decltype(xs2Times)>(xs_arr, xs_deque), xs2Times);
+    REQUIRE_EQ(append_convert<decltype(xs2Times)>(xs_arr, xs_arr), xs2Times);
+    REQUIRE_EQ(append_convert<decltype(xs2Times)>(xs_arr, xs_deque), xs2Times);
 }
 
 TEST_CASE("container_common_test, interweave")

--- a/test/container_common_test.cpp
+++ b/test/container_common_test.cpp
@@ -8,6 +8,7 @@
 #include "doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>
+#include <deque>
 
 namespace {
     auto squareLambda = [](int x) -> int { return x*x; };
@@ -21,8 +22,10 @@ namespace {
     typedef std::vector<bool> BoolVector;
     typedef std::vector<std::size_t> IdxVector;
     typedef std::array<int, 5> IntArray5;
+    typedef std::deque<int> IntDeque;
     IntVector xs = {1,2,2,3,2};
     IntArray5 xs_arr = {{1,2,2,3,2}};
+    IntDeque  xs_deque = {1,2,2,3,2};
     IntVector xs_reverse = {2,3,2,2,1};
     IntVector xsSorted = {1,2,2,2,3};
     IntVector xs2Times = {1,2,2,3,2,1,2,2,3,2};
@@ -190,7 +193,17 @@ TEST_CASE("container_common_test, prepend_elem")
 TEST_CASE("container_common_test, append")
 {
     using namespace fplus;
+    std::vector<int> xs_empty;
     REQUIRE_EQ(append(xs, xs), xs2Times);
+    REQUIRE_EQ(append(xs, xs_arr), xs2Times);
+    REQUIRE_EQ(append(xs, xs_empty), xs);
+}
+
+TEST_CASE("container_common_test, transform_append")
+{
+    using namespace fplus;
+    REQUIRE_EQ(transform_append<decltype(xs2Times)>(xs_arr, xs_arr), xs2Times);
+    REQUIRE_EQ(transform_append<decltype(xs2Times)>(xs_arr, xs_deque), xs2Times);
 }
 
 TEST_CASE("container_common_test, interweave")

--- a/test/fwd_test.cpp
+++ b/test/fwd_test.cpp
@@ -228,3 +228,14 @@ TEST_CASE("fwd_test, zip_with")
     REQUIRE_EQ(fwd::zip_with(multiply_int, ys)(xs), xs_mult_ys);
     REQUIRE_EQ(fwd::zip_with(multiply_generic, ys)(xs), xs_mult_ys);
 }
+
+TEST_CASE("fwd_test, append")
+{
+    using namespace fplus;
+
+    IntVector xs = {1,2,3,4,2};
+    IntVector ys = {2,2,3,1};
+    IntVector xs_append_ys = {1,2,3,4,2,2,2,3,1};
+
+    REQUIRE_EQ(fwd::append(xs)(ys), xs_append_ys);
+}


### PR DESCRIPTION
`append` now use 3 template parameters to allow different container types as input or output parameters.
`transform_append` is same as `append`, but easier to use different result container type.