### PR TITLE
compare.hpp : replace [](auto x, decltype(x) y) by static_assert

### DIFF
--- a/include/fplus/compare.hpp
+++ b/include/fplus/compare.hpp
@@ -471,8 +471,10 @@ bool xor_bools(const T& x, const T& y)
 template <typename Compare>
 auto ord_to_eq(Compare comp)
 {
-    return [comp](auto x, decltype(x) y)
+    return [comp](auto x, auto y)
     {
+        static_assert(std::is_same<decltype(x), decltype(y)>::value,
+            "Argument types must be the same");
         auto p = internal::ord_to_impl(comp)(x, y);
         return !p.first && !p.second;
     };
@@ -498,8 +500,10 @@ auto ord_to_not_eq(Compare comp)
 template <typename Compare>
 auto ord_eq_to_eq(Compare comp)
 {
-    return [comp](auto x, decltype(x) y)
+    return [comp](auto x, auto y)
     {
+        static_assert(std::is_same<decltype(x), decltype(y)>::value,
+            "Argument types must be the same");
         auto p = internal::ord_to_impl(comp)(x, y);
         return p.first && p.second;
     };

--- a/include/fplus/internal/compare.hpp
+++ b/include/fplus/internal/compare.hpp
@@ -18,8 +18,10 @@ namespace internal
 template <typename Compare>
 auto ord_to_impl(Compare comp)
 {
-    return [comp](auto x, decltype(x) y)
+    return [comp](auto x, auto y)
     {
+        static_assert(std::is_same<decltype(x), decltype(y)>::value,
+            "Argument types must be the same");
         using In = decltype(x);
         internal::trigger_static_asserts<internal::binary_predicate_tag, Compare, In, In>();
 


### PR DESCRIPTION
see https://stackoverflow.com/questions/51641219/msvc-lambda-with-two-auto-params-of-same-type#51641584

