### PR TITLE
format make_timed_function api doc

### DIFF
--- a/include/fplus/timed.hpp
+++ b/include/fplus/timed.hpp
@@ -76,9 +76,9 @@ namespace internal
 // API search type: make_timed_function : ((a -> b)) -> (a -> Timed b)
 // fwd bind count: 0
 // Transforms a function into a timed / benchmarked version of the same function.
-// 
+// -
 // Example:
-// 
+// -
 // using Ints = std::vector<int>;
 // Ints ascending_numbers = fplus::numbers(0, 1000);
 // Ints shuffled_numbers = fplus::shuffle(std::mt19937::default_seed, ascending_numbers);
@@ -87,7 +87,7 @@ namespace internal
 // auto sorted_numbers = sort_bench(shuffled_numbers);
 // assert(sorted_numbers.get() == ascending_numbers); // sorted_numbers.get() <=> actual output
 // assert(sorted_numbers.time_in_s() < 0.1); // // sorted_numbers.time_in_s() <=> execution time
-// 
+// -
 template<class Fn>
 auto make_timed_function(Fn f)
 {
@@ -123,15 +123,15 @@ namespace internal
 // API search type: make_timed_void_function : ((a -> Void)) -> (a -> Double)
 // fwd bind count: 0
 // Transforms a void function into a timed / benchmarked version of the same function.
-// 
+// -
 // Example:
-// 
+// -
 // void foo() { std::this_thread::sleep_for(std::chrono::milliseconds(1000)); }
 // ...
 // auto foo_bench = make_timed_void_function(foo);
 // auto r = foo_bench();
 // double run_time = foo_bench(); // in seconds
-// 
+// -
 template<class Fn>
 auto make_timed_void_function(Fn f)
 {

--- a/include/fplus/timed.hpp
+++ b/include/fplus/timed.hpp
@@ -76,19 +76,18 @@ namespace internal
 // API search type: make_timed_function : ((a -> b)) -> (a -> Timed b)
 // fwd bind count: 0
 // Transforms a function into a timed / benchmarked version of the same function.
-//
+// 
 // Example:
-//
+// 
 // using Ints = std::vector<int>;
 // Ints ascending_numbers = fplus::numbers(0, 1000);
 // Ints shuffled_numbers = fplus::shuffle(std::mt19937::default_seed, ascending_numbers);
 // auto sort_func = [](const Ints& values) { return fplus::sort(values); };
 // auto sort_bench = fplus::make_timed_function(sort_func);
 // auto sorted_numbers = sort_bench(shuffled_numbers);
-// // sorted_numbers.get() will return the actual computation output
-// assert(sorted_numbers.get() == ascending_numbers);
-// // sorted_numbers.time() will return the execution time in seconds
-// assert(sorted_numbers.time() < 0.1);
+// assert(sorted_numbers.get() == ascending_numbers); // sorted_numbers.get() <=> actual output
+// assert(sorted_numbers.time_in_s() < 0.1); // // sorted_numbers.time_in_s() <=> execution time
+// 
 template<class Fn>
 auto make_timed_function(Fn f)
 {
@@ -124,16 +123,15 @@ namespace internal
 // API search type: make_timed_void_function : ((a -> Void)) -> (a -> Double)
 // fwd bind count: 0
 // Transforms a void function into a timed / benchmarked version of the same function.
-//
+// 
 // Example:
-//
-// void foo() {
-//     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-// }
+// 
+// void foo() { std::this_thread::sleep_for(std::chrono::milliseconds(1000)); }
 // ...
 // auto foo_bench = make_timed_void_function(foo);
 // auto r = foo_bench();
 // double run_time = foo_bench(); // in seconds
+// 
 template<class Fn>
 auto make_timed_void_function(Fn f)
 {

--- a/include/fplus/timed.hpp
+++ b/include/fplus/timed.hpp
@@ -87,7 +87,6 @@ namespace internal
 // auto sorted_numbers = sort_bench(shuffled_numbers);
 // assert(sorted_numbers.get() == ascending_numbers); // sorted_numbers.get() <=> actual output
 // assert(sorted_numbers.time_in_s() < 0.1); // // sorted_numbers.time_in_s() <=> execution time
-// -
 template<class Fn>
 auto make_timed_function(Fn f)
 {
@@ -131,7 +130,6 @@ namespace internal
 // auto foo_bench = make_timed_void_function(foo);
 // auto r = foo_bench();
 // double run_time = foo_bench(); // in seconds
-// -
 template<class Fn>
 auto make_timed_void_function(Fn f)
 {


### PR DESCRIPTION
Hello

This is a simple PR in which I try to improve the doc rendering in the editgym website : 

* place code comments at end of code lines (instead of comment on the line before)
* add a blank line at the end of the doc ( with a trailing space after `//`, since I guess that is what is needed in order to hide the `//`)

![image](https://user-images.githubusercontent.com/7694091/46851059-7d249b00-cdf6-11e8-9e3c-9731a507bf99.png)
