### PR TITLE
Benchmark session

### DIFF
--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -264,13 +264,6 @@ make_benchmark_void_function(                                      \
 
 namespace internal
 {
-    // transform_and_sum is perhaps a nice addition to fplus
-    template <typename UnaryF, typename Container>
-    auto transform_and_sum(UnaryF unary_f, const Container& xs)
-    {
-        return fplus::sum(fplus::transform(unary_f, xs));
-    }
-
     inline std::string show_table(const std::vector<std::vector<std::string>>& rows)
     {
         if (rows.empty() || rows[0].empty())
@@ -299,12 +292,12 @@ namespace internal
         };
 
         auto show_one_row = [&](const std::vector<std::string> & row) {
-            return fplus::internal::transform_and_sum(
+            return fplus::sum(fplus::transform(
                 show_one_element, 
-                fplus::zip(row, columns_width));
+                fplus::zip(row, columns_width)));
         };
 
-        auto firstrow_separator = fplus::internal::transform_and_sum(show_one_separator, columns_width);
+        auto firstrow_separator = fplus::sum(fplus::transform(show_one_separator, columns_width));
         auto rows_formatted = fplus::transform(show_one_row, rows);
         auto rows_separated = fplus::insert_at_idx(1, firstrow_separator, rows_formatted);
         return fplus::join( std::string("\n"), rows_separated) + "\n";

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -114,6 +114,14 @@ namespace fplus
         return bench_function_impl<Fn>(session, name, f);
     }
 
+#define benchmark_expression(bench_session, name, expression)      \
+    make_benchmark_function(                                   \
+    bench_session,                                             \
+    name,                                                      \
+    [&]() { return expression; }                               \
+    )();
+
+#define COMMA ,
 
     template<class Fn>
     auto run_n_times(int nb_runs, Fn f)

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -155,50 +155,48 @@ namespace internal
 // Transforms a function into a function with the *same* signature
 // and behavior, except that it also stores stats into the benchmark session (first parameter),
 // under the name given by the second parameter.
-// (use make_benchmark_void_function if your function returns void).
-// Notes
-// -  make_benchmark_function *will add side effects* to the function
-// (since it stores data into the benchmark session at each call).
-// - If you intend to benchmark only one function, prefer to use the simpler `make_timed_function`
-// --------------------------------------------------
-// Example of a minimal benchmark session:
-// ---------------------------------------
-// fplus::benchmark_session benchmark_sess;
-// void foo() {
-//     auto add_bench = fplus::make_benchmark_function(benchmark_sess, "add", add);
-//     auto printf_bench = fplus::make_benchmark_void_function(benchmark_sess, "printf", printf);
-//     int forty_five = add_bench(20, add_bench(19, 6));
-//     int forty_two = benchmark_expression(benchmark_sess, "sub", forty_five - 3);
-//     printf_bench("forty_two is %i\n", forty_two);
-// }
-// void main() {
-//     foo();
-//     std::cout << benchmark_sess.report();
-// }
-// ----------------------------------------
-// This will output a report like this:
+// -
+// Notes:
+// Side effects: make_benchmark_function *will add side effects* to the function, since it stores data 
+// into the benchmark session at each call.
+// If you intend to benchmark only one function, prefer to use the simpler "make_timed_function"
+// Use "make_benchmark_void_function" if your function returns void
+// -
+// Example of a minimal benchmark session (read benchmark_session_test.cpp for a full example)
+//     fplus::benchmark_session benchmark_sess;
+//     void foo() {
+//         auto add_bench = fplus::make_benchmark_function(benchmark_sess, "add", add);
+//         auto printf_bench = fplus::make_benchmark_void_function(benchmark_sess, "printf", printf);
+//         int forty_five = add_bench(20, add_bench(19, 6));
+//         int forty_two = benchmark_expression(benchmark_sess, "sub", forty_five - 3);
+//         printf_bench("forty_two is %i\n", forty_two);
+//     }
+//     void main() {
+//         foo();
+//         std::cout << benchmark_sess.report();
+//     }
+// This will output a report like this
 // Function|Nb calls|Total time|Av. time|Deviation|
 // --------+--------+----------+--------+---------+
 // printf  |       1|   0.010ms| 9.952ns|  0.000ns|
 // add     |       2|   0.000ms| 0.050ns|  0.009ns|
 // sub     |       1|   0.000ms| 0.039ns|  0.000ns|
-// (Read benchmark_session_test.cpp for a full example)
-// -----------------------------------------
+// -
 // As an alternative to make_benchmark_function, you can also benchmark an expression.
-// For example, if you want to benchmark the following line:
+// For example, in order to benchmark the following line:
 //     auto sorted = fplus::sort(my_vector);
-// In order to do so, we just copy/paste this expression into "bench_expression" like shown below.
-// This expression will then be benchmarked with the name "sort_my_vector"
+// Just copy/paste this expression into "bench_expression" like shown below: this expression 
+// will then be benchmarked with the name "sort_my_vector"
 //     auto sorted = benchmark_expression(
 //         my_benchmark_session,
 //         "sort_my_vector",
 //         fplus::sort(my_vector);
 //     );
 // Notes :
-//  - benchmark_expression is a preprocessor macro that uses an immediately invoked lambda (IIL)
-// - the expression can be copy-pasted with no modification, and it is possible to not remove the ";"
-//   (although it also works if it is not present)
-// - you can also benchmark an expression that returns void using benchmark_void_expression
+// benchmark_expression is a preprocessor macro that uses an immediately invoked lambda (IIL).
+// The expression can be copy-pasted with no modification, and it is possible to not remove the ";"
+// (although it also works if it is not present)
+// You can also benchmark an expression that returns void using benchmark_void_expression
 template<class Fn>
 auto make_benchmark_function(benchmark_session & session, const FunctionName & name, Fn f)
 {
@@ -215,9 +213,8 @@ auto make_benchmark_function(benchmark_session & session, const FunctionName & n
 // under the name given by the second parameter
 // Note that make_benchmark_void_function *will add side effects* to the function
 // (since it stores data into the benchmark session at each call)
-// --------------------------------------------------
+// -
 // Example:
-// ---------------------------------------
 //     benchmark_session bench_session;
 //     ...
 //     void foo() { 

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -30,6 +30,8 @@ namespace internal
 class benchmark_session
 {
 public:
+    benchmark_session() : functions_times_mutex_(), functions_times_() {};
+
     // report() shall return a string with a summary of the session
     // Example below:
     // Function              |Nb calls|Total time|Av. time|Deviation|
@@ -70,7 +72,7 @@ private:
     }
 
     mutable std::mutex functions_times_mutex_;
-    std::map<FunctionName, std::vector<ExecutionTime>> functions_times_ = {};
+    std::map<FunctionName, std::vector<ExecutionTime>> functions_times_;
 };
 
 namespace internal 
@@ -306,7 +308,7 @@ namespace internal
         return result;
     }
 
-    std::vector< std::pair<FunctionName, benchmark_function_report> > make_ordered_reports(
+    inline std::vector< std::pair<FunctionName, benchmark_function_report> > make_ordered_reports(
         const std::map<FunctionName, benchmark_function_report> & report_map)
     {
         auto report_pairs = fplus::map_to_pairs(report_map);
@@ -316,7 +318,7 @@ namespace internal
         return report_pairs_sorted;
     }
 
-    std::string show_benchmark_function_report(const std::map<FunctionName, benchmark_function_report> & reports)
+    inline std::string show_benchmark_function_report(const std::map<FunctionName, benchmark_function_report> & reports)
     {
         auto ordered_reports = make_ordered_reports(reports);
         auto my_show_time_ms = [](double time) -> std::string {

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -25,6 +25,7 @@ namespace internal
     std::string show_benchmark_function_report(const std::map<FunctionName, benchmark_function_report> & reports);
 }
 
+
 // benchmark_session stores timings during a benchmark session
 // and is able to emit a report at the end
 class benchmark_session
@@ -138,6 +139,7 @@ namespace internal
 
 } // namespace internal
 
+
 // API search type: make_benchmark_function : (benchmark_session, string, (a... -> b)) -> (a... -> b)
 // fwd bind count: 0
 // Transforms a function into a function with the *same* signature
@@ -250,14 +252,13 @@ make_benchmark_void_function(                                      \
 
 
 template<class Fn>
-auto run_n_times(int nb_runs, Fn f)
+auto run_n_times(int nb_runs, Fn f) // run_n_times is perhaps a nice addition to fplus
 {
     for (auto _ : fplus::numbers(0, nb_runs)) {
         (void) _; // suppress warning / unused variable
         f();
     }
 }
-
 
 
 namespace internal
@@ -283,7 +284,6 @@ namespace internal
             return fplus::transform(largest_string_size, fplus::transpose(rows));
         }(); 
 
-
         auto show_one_element = [](const std::pair<std::string, size_t> & elem_and_width) {
             const std::string & element = elem_and_width.first;
             const auto col_width = elem_and_width.second;
@@ -298,7 +298,6 @@ namespace internal
             return fplus::show_fill_left('-', col_width, "") + "+";
         };
 
-
         auto show_one_row = [&](const std::vector<std::string> & row) {
             return fplus::internal::transform_and_sum(
                 show_one_element, 
@@ -306,7 +305,6 @@ namespace internal
         };
 
         auto firstrow_separator = fplus::internal::transform_and_sum(show_one_separator, columns_width);
-
         auto rows_formatted = fplus::transform(show_one_row, rows);
         auto rows_separated = fplus::insert_at_idx(1, firstrow_separator, rows_formatted);
         return fplus::join( std::string("\n"), rows_separated) + "\n";

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -1,0 +1,217 @@
+// Copyright 2015, Tobias Hermann and the FunctionalPlus contributors.
+// https://github.com/Dobiasd/FunctionalPlus
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#include <vector>
+#include <fplus/fplus.hpp>
+
+namespace fplus
+{
+    using FunctionName = std::string;
+    struct benchmark_function_report
+    {
+        std::string function_name;
+        size_t nb_calls;
+        ExecutionTime total_time;
+        ExecutionTime average_time;
+        ExecutionTime deviation;
+    };
+
+    namespace internal
+    {
+        std::string show_benchmark_function_report(const std::vector<benchmark_function_report> & reports);
+    }
+
+    // benchmark_session stores timings during a benchmark session
+    // and is able to emit a report at the end
+    class benchmark_session
+    {
+    public:
+        // report() shall return a string with a summary of the session
+        // Example below:
+        // Function              |Nb calls|Total time|Av. time|Deviation|
+        // ----------------------+--------+----------+--------+---------+
+        // convert_charset_string|    4000|   4.942ms| 1.236ns|  1.390ns|
+        // split_lines           |    1000|   4.528ms| 4.528ns|  1.896ns|
+        inline std::string report() const {
+            const auto reports = report_list();
+            return fplus::internal::show_benchmark_function_report(reports);
+        }
+
+        std::vector<benchmark_function_report> report_list() const
+        {
+            std::vector<benchmark_function_report> report;
+            for (const auto & one_function_time : functions_times_)
+                report.push_back(make_bench_report(one_function_time.first, one_function_time.second));
+            // sort by total_time descending
+            auto report_sorted = fplus::sort_by([](const benchmark_function_report &a, const benchmark_function_report &b) {
+                return a.total_time > b.total_time;
+            }, report);
+            return report_sorted;
+        }
+
+        inline void store_one_time(const FunctionName & function_name, ExecutionTime time) {
+            functions_times_[function_name].push_back(time);
+        }
+
+    private:
+        benchmark_function_report make_bench_report(
+            const FunctionName & function_name, const std::vector<ExecutionTime> & times) const
+        {
+            benchmark_function_report result;
+            result.function_name = function_name;            
+            result.nb_calls = times.size();
+            auto mean_and_dev = fplus::mean_stddev<double>(times);
+            result.average_time = mean_and_dev.first;
+            result.deviation = mean_and_dev.second;
+            result.total_time = fplus::sum(times);
+            return result;
+        }
+
+        std::map<FunctionName, std::vector<ExecutionTime>> functions_times_;
+    };
+
+
+    template<typename Fn>
+    class bench_function_impl
+    {
+    public:
+        explicit bench_function_impl(
+            benchmark_session & benchmark_sess,
+            FunctionName function_name,
+            Fn fn) 
+            : benchmark_session_(benchmark_sess)
+            , function_name_(function_name)
+            , fn_(fn)
+        {};
+
+        template<typename ...Args> auto operator()(Args... args) { return _bench_result(args...); }
+
+    private:
+        template<typename ...Args>
+        auto _bench_result(Args... args)
+        {
+            fplus::stopwatch timer;
+            auto r = fn_(args...);
+            benchmark_session_.store_one_time(function_name_, timer.elapsed());
+            return r;
+        }
+
+        benchmark_session & benchmark_session_;
+        FunctionName function_name_;
+        Fn fn_;
+        fplus::maybe<int> v;
+    };
+
+
+    template<class Fn>
+    auto make_benchmark_function(benchmark_session & session, const FunctionName & name, Fn f)
+    {
+        // transforms f into a function with the same 
+        // signature, that will store timings into the benchmark session
+        return bench_function_impl<Fn>(session, name, f);
+    }
+
+
+    template<class Fn>
+    auto run_n_times(int nb_runs, Fn f)
+    {
+        for (auto _ : fplus::numbers(0, nb_runs))
+            f();
+    }
+
+
+    namespace internal
+    {
+        inline std::string show_tableau(std::vector<std::vector<std::string>> & rows, bool add_firstrow_separator)
+        {
+            if (rows.empty())
+                return "";
+            if (rows[0].empty())
+                return "";
+            auto string_size = [](const std::string & s) -> size_t { return s.size(); };
+            auto get_item = [&](size_t row, size_t col) {
+                return rows[row][col];
+            };
+            auto largest_string_size = [&](const std::vector<std::string> & strings) -> size_t {
+                return string_size(fplus::maximum_on(string_size, strings));
+            };
+
+            size_t nb_rows = rows.size();
+            size_t nb_cols = rows[0].size();
+
+            std::vector<size_t> columns_width;
+            {
+                auto columns = fplus::transpose(rows);
+                columns_width = fplus::transform(largest_string_size, columns);
+            }
+
+            auto show_one_row = [&](size_t row) {
+                std::string result;
+                for (size_t col = 0; col < nb_cols; col++)
+                {
+                    const std::string & element = get_item(row, col);
+                    bool is_number = element.size() > 0 && isdigit(element[0]);
+                    auto col_width = columns_width[col];
+                    if (is_number)
+                        result = result + fplus::show_fill_left(' ', col_width, element) + "|";
+                    else
+                        result = result + fplus::show_fill_right(' ', col_width, element) + "|";
+                }
+                return result;
+            };
+
+            auto show_firstrow_separator = [&]() {
+                std::string result;
+                for (size_t col = 0; col < nb_cols; col++)
+                    result = result + fplus::show_fill_left('-', columns_width[col], "") + "+";
+                return result;
+            };
+
+            std::string result = show_one_row(0) + "\n";
+            if (add_firstrow_separator)
+                result += show_firstrow_separator() + "\n";
+            for (size_t row = 1; row < nb_rows; row++)
+                result += show_one_row(row) + "\n";
+
+            return result;
+        }
+
+        std::string show_benchmark_function_report(const std::vector<benchmark_function_report> & reports)
+        {
+            auto my_show_time_ms = [](double time) -> std::string {
+                std::stringstream ss;
+                ss << std::fixed << std::setprecision(3);
+                ss << (time * 1000.);
+                return ss.str() + "ms";
+            };
+            auto my_show_time_ns = [](double time) -> std::string {
+                std::stringstream ss;
+                ss << std::fixed << std::setprecision(3);
+                ss << (time * 1000000.);
+                return ss.str() + "ns";
+            };
+
+            std::vector<std::string> header_row{ {
+                    "Function", "Nb calls", "Total time", "Av. time", "Deviation"
+                } };
+            std::vector<std::vector<std::string>> tableau_rows;
+            tableau_rows.push_back(header_row);
+            for (const auto & report : reports)
+            {
+                std::vector<std::string> row;
+                row.push_back(report.function_name);
+                row.push_back(fplus::show(report.nb_calls));
+                row.push_back(my_show_time_ms(report.total_time));
+                row.push_back(my_show_time_ns(report.average_time));
+                row.push_back(my_show_time_ns(report.deviation));
+                tableau_rows.push_back(row);
+            }
+
+            return fplus::internal::show_tableau(tableau_rows, true);
+        }
+    } // namespace internal 
+
+}

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -156,14 +156,13 @@ namespace internal
 // and behavior, except that it also stores stats into the benchmark session (first parameter),
 // under the name given by the second parameter.
 // (use make_benchmark_void_function if your function returns void).
-//
-// Note that make_benchmark_function *will add side effects* to the function
+// Notes
+// -  make_benchmark_function *will add side effects* to the function
 // (since it stores data into the benchmark session at each call).
-//
-// If you intend to benchmark only one function, prefer to use the simpler `make_timed_function`
-//
+// - If you intend to benchmark only one function, prefer to use the simpler `make_timed_function`
+// --------------------------------------------------
 // Example of a minimal benchmark session:
-//
+// ---------------------------------------
 // fplus::benchmark_session benchmark_sess;
 // void foo() {
 //     auto add_bench = fplus::make_benchmark_function(benchmark_sess, "add", add);
@@ -176,38 +175,30 @@ namespace internal
 //     foo();
 //     std::cout << benchmark_sess.report();
 // }
-//
+// ----------------------------------------
 // This will output a report like this:
 // Function|Nb calls|Total time|Av. time|Deviation|
 // --------+--------+----------+--------+---------+
 // printf  |       1|   0.010ms| 9.952ns|  0.000ns|
 // add     |       2|   0.000ms| 0.050ns|  0.009ns|
 // sub     |       1|   0.000ms| 0.039ns|  0.000ns|
-//
 // (Read benchmark_session_test.cpp for a full example)
-//
-// ----------------------------------------------------------
-//
+// -----------------------------------------
 // As an alternative to make_benchmark_function, you can also benchmark an expression.
 // For example, if you want to benchmark the following line:
-//
 //     auto sorted = fplus::sort(my_vector);
-//
-// In order to do so, ye just copy/paste this expression into "bench_expression" like shown below.
+// In order to do so, we just copy/paste this expression into "bench_expression" like shown below.
 // This expression will then be benchmarked with the name "sort_my_vector"
-//
-// auto sorted = benchmark_expression(
-//     my_benchmark_session,
-//     "sort_my_vector",
-//     fplus::sort(my_vector);
-// );
-//
+//     auto sorted = benchmark_expression(
+//         my_benchmark_session,
+//         "sort_my_vector",
+//         fplus::sort(my_vector);
+//     );
 // Notes :
 //  - benchmark_expression is a preprocessor macro that uses an immediately invoked lambda (IIL)
 // - the expression can be copy-pasted with no modification, and it is possible to not remove the ";"
 //   (although it also works if it is not present)
 // - you can also benchmark an expression that returns void using benchmark_void_expression
-//
 template<class Fn>
 auto make_benchmark_function(benchmark_session & session, const FunctionName & name, Fn f)
 {
@@ -222,23 +213,21 @@ auto make_benchmark_function(benchmark_session & session, const FunctionName & n
 // Transforms a function that returns a void into a function with the *same* signature
 // and behavior, except that it also stores stats into the benchmark session (first parameter),
 // under the name given by the second parameter
-//
 // Note that make_benchmark_void_function *will add side effects* to the function
 // (since it stores data into the benchmark session at each call)
-//
+// --------------------------------------------------
 // Example:
-//
-// benchmark_session bench_session;
-// ...
-// void foo() { 
-//     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-// }
-// ...
-// auto foo_bench = make_benchmark_void_function(bench_session, "foo", foo);
-// foo_bench();
-// ...
-// std::cout << benchmark_session.report();
-//
+// ---------------------------------------
+//     benchmark_session bench_session;
+//     ...
+//     void foo() { 
+//         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+//     }
+//     ...
+//     auto foo_bench = make_benchmark_void_function(bench_session, "foo", foo);
+//     foo_bench();
+//     ...
+//     std::cout << benchmark_session.report();
 template<class Fn>
 auto make_benchmark_void_function(benchmark_session & session, const FunctionName & name, Fn f)
 {

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -22,7 +22,8 @@ struct benchmark_function_report
 
 namespace internal
 {
-    std::string show_benchmark_function_report(const std::map<FunctionName, benchmark_function_report> & reports);
+    std::string show_benchmark_function_report(
+        const std::map<FunctionName, benchmark_function_report> & reports);
 }
 
 
@@ -50,7 +51,9 @@ public:
         std::lock_guard<std::mutex> lock(functions_times_mutex_);
         std::map<FunctionName, benchmark_function_report> report;
         for (const auto & one_function_time : functions_times_)
+        {
             report[one_function_time.first] = make_bench_report(one_function_time.second);
+        }
         return report;
     }
 
@@ -61,7 +64,8 @@ public:
     }
 
 private:
-    benchmark_function_report make_bench_report(const std::vector<ExecutionTime> & times) const
+    benchmark_function_report make_bench_report(
+        const std::vector<ExecutionTime> & times) const
     {
         benchmark_function_report result;
         result.nb_calls = times.size();
@@ -91,7 +95,10 @@ namespace internal
             , fn_(fn)
         {};
 
-        template<typename ...Args> auto operator()(Args... args) { return _bench_result(args...); }
+        template<typename ...Args> auto operator()(Args... args) 
+        { 
+            return _bench_result(args...); 
+        }
 
     private:
         template<typename ...Args>
@@ -121,7 +128,10 @@ namespace internal
             , fn_(fn)
         {};
 
-        template<typename ...Args> auto operator()(Args... args) { _bench_result(args...); }
+        template<typename ...Args> auto operator()(Args... args) 
+        { 
+            _bench_result(args...); 
+        }
 
     private:
         template<typename ...Args>
@@ -228,6 +238,7 @@ auto make_benchmark_function(benchmark_session & session, const FunctionName & n
 // foo_bench();
 // ...
 // std::cout << benchmark_session.report();
+//
 template<class Fn>
 auto make_benchmark_void_function(benchmark_session & session, const FunctionName & name, Fn f)
 {
@@ -271,7 +282,7 @@ namespace internal
     }
 
 
-    inline std::string show_tableau(const std::vector<std::vector<std::string>> & rows)
+    inline std::string show_tableau(const std::vector<std::vector<std::string>>& rows)
     {
         if (rows.empty() || rows[0].empty())
             return "";

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -262,16 +262,6 @@ make_benchmark_void_function(                                      \
 )();
 
 
-template<class Fn>
-auto run_n_times(int nb_runs, Fn f) // run_n_times is perhaps a nice addition to fplus
-{
-    for (auto _ : fplus::numbers(0, nb_runs)) {
-        (void) _; // suppress warning / unused variable
-        f();
-    }
-}
-
-
 namespace internal
 {
     // transform_and_sum is perhaps a nice addition to fplus
@@ -280,7 +270,6 @@ namespace internal
     {
         return fplus::sum(fplus::transform(unary_f, xs));
     }
-
 
     inline std::string show_table(const std::vector<std::vector<std::string>>& rows)
     {

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -153,7 +153,6 @@ namespace internal
 
 
 // API search type: make_benchmark_function : (benchmark_session, string, (a... -> b)) -> (a... -> b)
-// fwd bind count: 0
 // Transforms a function into a function with the *same* signature
 // and behavior, except that it also stores stats into the benchmark session (first parameter),
 // under the name given by the second parameter.
@@ -209,7 +208,6 @@ auto make_benchmark_function(benchmark_session & session, const FunctionName & n
 
 
 // API search type: make_benchmark_void_function : (benchmark_session, string, (a... -> Void)) -> (a... -> Void)
-// fwd bind count: 0
 // Transforms a function that returns a void into a function with the *same* signature
 // and behavior, except that it also stores stats into the benchmark session (first parameter),
 // under the name given by the second parameter

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -13,7 +13,7 @@ namespace fplus
 using FunctionName = std::string;
 struct benchmark_function_report
 {
-    size_t nb_calls;
+    std::size_t nb_calls;
     ExecutionTime total_time;
     ExecutionTime average_time;
     ExecutionTime deviation;
@@ -276,15 +276,15 @@ namespace internal
         if (rows.empty() || rows[0].empty())
             return "";
 
-        const std::vector<size_t> columns_width = [&]() {
-            auto string_size = [](const std::string & s) -> size_t { return s.size(); };
-            auto largest_string_size = [&](const std::vector<std::string> & strings) -> size_t {
+        const std::vector<std::size_t> columns_width = [&]() {
+            auto string_size = [](const std::string & s) -> std::size_t { return s.size(); };
+            auto largest_string_size = [&](const std::vector<std::string> & strings) -> std::size_t {
                 return string_size(fplus::maximum_on(string_size, strings));
             };
             return fplus::transform(largest_string_size, fplus::transpose(rows));
         }(); 
 
-        auto show_one_element = [](const std::pair<std::string, size_t> & elem_and_width) {
+        auto show_one_element = [](const std::pair<std::string, std::size_t> & elem_and_width) {
             const std::string & element = elem_and_width.first;
             const auto col_width = elem_and_width.second;
             bool is_number = element.size() > 0 && isdigit(element[0]);
@@ -294,7 +294,7 @@ namespace internal
                 return fplus::show_fill_right(' ', col_width, element) + "|";
         };
 
-        auto show_one_separator = [](size_t col_width) {
+        auto show_one_separator = [](std::size_t col_width) {
             return fplus::show_fill_left('-', col_width, "") + "+";
         };
 

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -282,7 +282,7 @@ namespace internal
     }
 
 
-    inline std::string show_tableau(const std::vector<std::vector<std::string>>& rows)
+    inline std::string show_table(const std::vector<std::vector<std::string>>& rows)
     {
         if (rows.empty() || rows[0].empty())
             return "";
@@ -363,7 +363,7 @@ namespace internal
             }, 
             ordered_reports);
 
-        return fplus::internal::show_tableau(fplus::insert_at_idx(0, header_row, value_rows));
+        return fplus::internal::show_table(fplus::insert_at_idx(0, header_row, value_rows));
     }
 } // namespace internal 
 

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -8,6 +8,8 @@
 #include <mutex>
 #include <fplus/fplus.hpp>
 
+#pragma once
+
 namespace fplus
 {
 using FunctionName = std::string;

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -234,13 +234,19 @@ auto make_benchmark_void_function(benchmark_session & session, const FunctionNam
 }
 
 #define benchmark_expression(bench_session, name, expression)      \
-make_benchmark_function(                                       \
-    bench_session,                                             \
-    name,                                                      \
-    [&]() { return expression; }                               \
+make_benchmark_function(                                           \
+    bench_session,                                                 \
+    name,                                                          \
+    [&]() { return expression; }                                   \
 )();
 
-#define COMMA ,
+#define benchmark_void_expression(bench_session, name, expression) \
+make_benchmark_void_function(                                      \
+    bench_session,                                                 \
+    name,                                                          \
+    [&]() { expression; }                                          \
+)();
+
 
 template<class Fn>
 auto run_n_times(int nb_runs, Fn f)

--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -10,348 +10,348 @@
 
 namespace fplus
 {
-    using FunctionName = std::string;
-    struct benchmark_function_report
-    {
-        size_t nb_calls;
-        ExecutionTime total_time;
-        ExecutionTime average_time;
-        ExecutionTime deviation;
-    };
+using FunctionName = std::string;
+struct benchmark_function_report
+{
+    size_t nb_calls;
+    ExecutionTime total_time;
+    ExecutionTime average_time;
+    ExecutionTime deviation;
+};
 
 
-    namespace internal
+namespace internal
+{
+    std::string show_benchmark_function_report(const std::map<FunctionName, benchmark_function_report> & reports);
+}
+
+// benchmark_session stores timings during a benchmark session
+// and is able to emit a report at the end
+class benchmark_session
+{
+public:
+    // report() shall return a string with a summary of the session
+    // Example below:
+    // Function              |Nb calls|Total time|Av. time|Deviation|
+    // ----------------------+--------+----------+--------+---------+
+    // convert_charset_string|    4000|   4.942ms| 1.236ns|  1.390ns|
+    // split_lines           |    1000|   4.528ms| 4.528ns|  1.896ns|
+    inline std::string report() const 
     {
-        std::string show_benchmark_function_report(const std::map<FunctionName, benchmark_function_report> & reports);
+        const auto reports = report_list();
+        return fplus::internal::show_benchmark_function_report(reports);
     }
 
-    // benchmark_session stores timings during a benchmark session
-    // and is able to emit a report at the end
-    class benchmark_session
+    std::map<FunctionName, benchmark_function_report> report_list() const
+    {
+        std::lock_guard<std::mutex> lock(functions_times_mutex_);
+        std::map<FunctionName, benchmark_function_report> report;
+        for (const auto & one_function_time : functions_times_)
+            report[one_function_time.first] = make_bench_report(one_function_time.second);
+        return report;
+    }
+
+    inline void store_one_time(const FunctionName & function_name, ExecutionTime time) 
+    {
+        std::lock_guard<std::mutex> lock(functions_times_mutex_);
+        functions_times_[function_name].push_back(time);
+    }
+
+private:
+    benchmark_function_report make_bench_report(const std::vector<ExecutionTime> & times) const
+    {
+        benchmark_function_report result;
+        result.nb_calls = times.size();
+        auto mean_and_dev = fplus::mean_stddev<double>(times);
+        result.average_time = mean_and_dev.first;
+        result.deviation = mean_and_dev.second;
+        result.total_time = fplus::sum(times);
+        return result;
+    }
+
+    mutable std::mutex functions_times_mutex_;
+    std::map<FunctionName, std::vector<ExecutionTime>> functions_times_ = {};
+};
+
+namespace internal 
+{
+    template<typename Fn>
+    class bench_function_impl
     {
     public:
-        // report() shall return a string with a summary of the session
-        // Example below:
-        // Function              |Nb calls|Total time|Av. time|Deviation|
-        // ----------------------+--------+----------+--------+---------+
-        // convert_charset_string|    4000|   4.942ms| 1.236ns|  1.390ns|
-        // split_lines           |    1000|   4.528ms| 4.528ns|  1.896ns|
-        inline std::string report() const 
-        {
-            const auto reports = report_list();
-            return fplus::internal::show_benchmark_function_report(reports);
-        }
+        explicit bench_function_impl(
+            benchmark_session & benchmark_sess,
+            FunctionName function_name,
+            Fn fn) 
+            : benchmark_session_(benchmark_sess)
+            , function_name_(function_name)
+            , fn_(fn)
+        {};
 
-        std::map<FunctionName, benchmark_function_report> report_list() const
-        {
-            std::lock_guard<std::mutex> lock(functions_times_mutex_);
-            std::map<FunctionName, benchmark_function_report> report;
-            for (const auto & one_function_time : functions_times_)
-                report[one_function_time.first] = make_bench_report(one_function_time.second);
-            return report;
-        }
-
-        inline void store_one_time(const FunctionName & function_name, ExecutionTime time) 
-        {
-            std::lock_guard<std::mutex> lock(functions_times_mutex_);
-            functions_times_[function_name].push_back(time);
-        }
+        template<typename ...Args> auto operator()(Args... args) { return _bench_result(args...); }
 
     private:
-        benchmark_function_report make_bench_report(const std::vector<ExecutionTime> & times) const
+        template<typename ...Args>
+        auto _bench_result(Args... args)
         {
-            benchmark_function_report result;
-            result.nb_calls = times.size();
-            auto mean_and_dev = fplus::mean_stddev<double>(times);
-            result.average_time = mean_and_dev.first;
-            result.deviation = mean_and_dev.second;
-            result.total_time = fplus::sum(times);
-            return result;
+            fplus::stopwatch timer;
+            auto r = fn_(args...);
+            benchmark_session_.store_one_time(function_name_, timer.elapsed());
+            return r;
         }
 
-        mutable std::mutex functions_times_mutex_;
-        std::map<FunctionName, std::vector<ExecutionTime>> functions_times_ = {};
+        benchmark_session & benchmark_session_;
+        FunctionName function_name_;
+        Fn fn_;
     };
 
-    namespace internal 
+    template<typename Fn>
+    class bench_void_function_impl
     {
-        template<typename Fn>
-        class bench_function_impl
+    public:
+        explicit bench_void_function_impl(
+            benchmark_session & benchmark_sess,
+            FunctionName function_name,
+            Fn fn) 
+            : benchmark_session_(benchmark_sess)
+            , function_name_(function_name)
+            , fn_(fn)
+        {};
+
+        template<typename ...Args> auto operator()(Args... args) { _bench_result(args...); }
+
+    private:
+        template<typename ...Args>
+        auto _bench_result(Args... args)
         {
-        public:
-            explicit bench_function_impl(
-                benchmark_session & benchmark_sess,
-                FunctionName function_name,
-                Fn fn) 
-                : benchmark_session_(benchmark_sess)
-                , function_name_(function_name)
-                , fn_(fn)
-            {};
+            fplus::stopwatch timer;
+            fn_(args...);
+            benchmark_session_.store_one_time(function_name_, timer.elapsed());
+        }
 
-            template<typename ...Args> auto operator()(Args... args) { return _bench_result(args...); }
+        benchmark_session & benchmark_session_;
+        FunctionName function_name_;
+        Fn fn_;
+    };
 
-        private:
-            template<typename ...Args>
-            auto _bench_result(Args... args)
-            {
-                fplus::stopwatch timer;
-                auto r = fn_(args...);
-                benchmark_session_.store_one_time(function_name_, timer.elapsed());
-                return r;
-            }
+} // namespace internal
 
-            benchmark_session & benchmark_session_;
-            FunctionName function_name_;
-            Fn fn_;
-        };
-
-        template<typename Fn>
-        class bench_void_function_impl
-        {
-        public:
-            explicit bench_void_function_impl(
-                benchmark_session & benchmark_sess,
-                FunctionName function_name,
-                Fn fn) 
-                : benchmark_session_(benchmark_sess)
-                , function_name_(function_name)
-                , fn_(fn)
-            {};
-
-            template<typename ...Args> auto operator()(Args... args) { _bench_result(args...); }
-
-        private:
-            template<typename ...Args>
-            auto _bench_result(Args... args)
-            {
-                fplus::stopwatch timer;
-                fn_(args...);
-                benchmark_session_.store_one_time(function_name_, timer.elapsed());
-            }
-
-            benchmark_session & benchmark_session_;
-            FunctionName function_name_;
-            Fn fn_;
-        };
-
-    } // namespace internal
-
-    // API search type: make_benchmark_function : (benchmark_session, string, (a... -> b)) -> (a... -> b)
-    // fwd bind count: 0
-    // Transforms a function into a function with the *same* signature
-    // and behavior, except that it also stores stats into the benchmark session (first parameter),
-    // under the name given by the second parameter.
-    // (use make_benchmark_void_function if your function returns void).
-    //
-    // Note that make_benchmark_function *will add side effects* to the function
-    // (since it stores data into the benchmark session at each call).
-    //
-    // If you intend to benchmark only one function, prefer to use the simpler `make_timed_function`
-    //
-    // Example of a minimal benchmark session:
-    //
-    // fplus::benchmark_session benchmark_sess;
-    // void foo() {
-    //     auto add_bench = fplus::make_benchmark_function(benchmark_sess, "add", add);
-    //     auto printf_bench = fplus::make_benchmark_void_function(benchmark_sess, "printf", printf);
-    //     int forty_five = add_bench(20, add_bench(19, 6));
-    //     int forty_two = benchmark_expression(benchmark_sess, "sub", forty_five - 3);
-    //     printf_bench("forty_two is %i\n", forty_two);
-    // }
-    // void main() {
-    //     foo();
-    //     std::cout << benchmark_sess.report();
-    // }
-    //
-    // This will output a report like this:
-    // Function|Nb calls|Total time|Av. time|Deviation|
-    // --------+--------+----------+--------+---------+
-    // printf  |       1|   0.010ms| 9.952ns|  0.000ns|
-    // add     |       2|   0.000ms| 0.050ns|  0.009ns|
-    // sub     |       1|   0.000ms| 0.039ns|  0.000ns|
-    //
-    // (Read benchmark_session_test.cpp for a full example)
-    //
-    // ----------------------------------------------------------
-    //
-    // As an alternative to make_benchmark_function, you can also benchmark an expression.
-    // For example, if you want to benchmark the following line:
-    //
-    //     auto sorted = fplus::sort(my_vector);
-    //
-    // In order to do so, ye just copy/paste this expression into "bench_expression" like shown below.
-    // This expression will then be benchmarked with the name "sort_my_vector"
-    //
-    // auto sorted = benchmark_expression(
-    //     my_benchmark_session,
-    //     "sort_my_vector",
-    //     fplus::sort(my_vector);
-    // );
-    //
-    // Notes :
-    //  - benchmark_expression is a preprocessor macro that uses an immediately invoked lambda (IIL)
-    // - the expression can be copy-pasted with no modification, and it is possible to not remove the ";"
-    //   (although it also works if it is not present)
-    //
-    template<class Fn>
-    auto make_benchmark_function(benchmark_session & session, const FunctionName & name, Fn f)
-    {
-        // transforms f into a function with the same 
-        // signature, that will store timings into the benchmark session
-        return internal::bench_function_impl<Fn>(session, name, f);
-    }
+// API search type: make_benchmark_function : (benchmark_session, string, (a... -> b)) -> (a... -> b)
+// fwd bind count: 0
+// Transforms a function into a function with the *same* signature
+// and behavior, except that it also stores stats into the benchmark session (first parameter),
+// under the name given by the second parameter.
+// (use make_benchmark_void_function if your function returns void).
+//
+// Note that make_benchmark_function *will add side effects* to the function
+// (since it stores data into the benchmark session at each call).
+//
+// If you intend to benchmark only one function, prefer to use the simpler `make_timed_function`
+//
+// Example of a minimal benchmark session:
+//
+// fplus::benchmark_session benchmark_sess;
+// void foo() {
+//     auto add_bench = fplus::make_benchmark_function(benchmark_sess, "add", add);
+//     auto printf_bench = fplus::make_benchmark_void_function(benchmark_sess, "printf", printf);
+//     int forty_five = add_bench(20, add_bench(19, 6));
+//     int forty_two = benchmark_expression(benchmark_sess, "sub", forty_five - 3);
+//     printf_bench("forty_two is %i\n", forty_two);
+// }
+// void main() {
+//     foo();
+//     std::cout << benchmark_sess.report();
+// }
+//
+// This will output a report like this:
+// Function|Nb calls|Total time|Av. time|Deviation|
+// --------+--------+----------+--------+---------+
+// printf  |       1|   0.010ms| 9.952ns|  0.000ns|
+// add     |       2|   0.000ms| 0.050ns|  0.009ns|
+// sub     |       1|   0.000ms| 0.039ns|  0.000ns|
+//
+// (Read benchmark_session_test.cpp for a full example)
+//
+// ----------------------------------------------------------
+//
+// As an alternative to make_benchmark_function, you can also benchmark an expression.
+// For example, if you want to benchmark the following line:
+//
+//     auto sorted = fplus::sort(my_vector);
+//
+// In order to do so, ye just copy/paste this expression into "bench_expression" like shown below.
+// This expression will then be benchmarked with the name "sort_my_vector"
+//
+// auto sorted = benchmark_expression(
+//     my_benchmark_session,
+//     "sort_my_vector",
+//     fplus::sort(my_vector);
+// );
+//
+// Notes :
+//  - benchmark_expression is a preprocessor macro that uses an immediately invoked lambda (IIL)
+// - the expression can be copy-pasted with no modification, and it is possible to not remove the ";"
+//   (although it also works if it is not present)
+//
+template<class Fn>
+auto make_benchmark_function(benchmark_session & session, const FunctionName & name, Fn f)
+{
+    // transforms f into a function with the same 
+    // signature, that will store timings into the benchmark session
+    return internal::bench_function_impl<Fn>(session, name, f);
+}
 
 
-    // API search type: make_benchmark_void_function : (benchmark_session, string, (a... -> Void)) -> (a... -> Void)
-    // fwd bind count: 0
-    // Transforms a function that returns a void into a function with the *same* signature
-    // and behavior, except that it also stores stats into the benchmark session (first parameter),
-    // under the name given by the second parameter
-    //
-    // Note that make_benchmark_void_function *will add side effects* to the function
-    // (since it stores data into the benchmark session at each call)
-    //
-    // Example:
-    //
-    // benchmark_session bench_session;
-    // ...
-    // void foo() { 
-    //     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-    // }
-    // ...
-    // auto foo_bench = make_benchmark_void_function(bench_session, "foo", foo);
-    // foo_bench();
-    // ...
-    // std::cout << benchmark_session.report();
-    template<class Fn>
-    auto make_benchmark_void_function(benchmark_session & session, const FunctionName & name, Fn f)
-    {
-        // transforms a void returning function into a function with the same 
-        // signature, that will store timings into the benchmark session
-        return internal::bench_void_function_impl<Fn>(session, name, f);
-    }
+// API search type: make_benchmark_void_function : (benchmark_session, string, (a... -> Void)) -> (a... -> Void)
+// fwd bind count: 0
+// Transforms a function that returns a void into a function with the *same* signature
+// and behavior, except that it also stores stats into the benchmark session (first parameter),
+// under the name given by the second parameter
+//
+// Note that make_benchmark_void_function *will add side effects* to the function
+// (since it stores data into the benchmark session at each call)
+//
+// Example:
+//
+// benchmark_session bench_session;
+// ...
+// void foo() { 
+//     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+// }
+// ...
+// auto foo_bench = make_benchmark_void_function(bench_session, "foo", foo);
+// foo_bench();
+// ...
+// std::cout << benchmark_session.report();
+template<class Fn>
+auto make_benchmark_void_function(benchmark_session & session, const FunctionName & name, Fn f)
+{
+    // transforms a void returning function into a function with the same 
+    // signature, that will store timings into the benchmark session
+    return internal::bench_void_function_impl<Fn>(session, name, f);
+}
 
 #define benchmark_expression(bench_session, name, expression)      \
-    make_benchmark_function(                                       \
-        bench_session,                                             \
-        name,                                                      \
-        [&]() { return expression; }                               \
-    )();
+make_benchmark_function(                                       \
+    bench_session,                                             \
+    name,                                                      \
+    [&]() { return expression; }                               \
+)();
 
 #define COMMA ,
 
-    template<class Fn>
-    auto run_n_times(int nb_runs, Fn f)
+template<class Fn>
+auto run_n_times(int nb_runs, Fn f)
+{
+    for (auto _ : fplus::numbers(0, nb_runs)) {
+        (void) _; // suppress warning / unused variable
+        f();
+    }
+}
+
+
+namespace internal
+{
+    inline std::string show_tableau(std::vector<std::vector<std::string>> & rows, bool add_firstrow_separator)
     {
-        for (auto _ : fplus::numbers(0, nb_runs)) {
-            (void) _; // suppress warning / unused variable
-            f();
+        if (rows.empty())
+            return "";
+        if (rows[0].empty())
+            return "";
+        auto string_size = [](const std::string & s) -> size_t { return s.size(); };
+        auto get_item = [&](size_t row, size_t col) {
+            return rows[row][col];
+        };
+        auto largest_string_size = [&](const std::vector<std::string> & strings) -> size_t {
+            return string_size(fplus::maximum_on(string_size, strings));
+        };
+
+        size_t nb_rows = rows.size();
+        size_t nb_cols = rows[0].size();
+
+        std::vector<size_t> columns_width;
+        {
+            auto columns = fplus::transpose(rows);
+            columns_width = fplus::transform(largest_string_size, columns);
         }
+
+        auto show_one_row = [&](size_t row) {
+            std::string result;
+            for (size_t col = 0; col < nb_cols; col++)
+            {
+                const std::string & element = get_item(row, col);
+                bool is_number = element.size() > 0 && isdigit(element[0]);
+                auto col_width = columns_width[col];
+                if (is_number)
+                    result = result + fplus::show_fill_left(' ', col_width, element) + "|";
+                else
+                    result = result + fplus::show_fill_right(' ', col_width, element) + "|";
+            }
+            return result;
+        };
+
+        auto show_firstrow_separator = [&]() {
+            std::string result;
+            for (size_t col = 0; col < nb_cols; col++)
+                result = result + fplus::show_fill_left('-', columns_width[col], "") + "+";
+            return result;
+        };
+
+        std::string result = show_one_row(0) + "\n";
+        if (add_firstrow_separator)
+            result += show_firstrow_separator() + "\n";
+        for (size_t row = 1; row < nb_rows; row++)
+            result += show_one_row(row) + "\n";
+
+        return result;
     }
 
-
-    namespace internal
+    std::vector< std::pair<FunctionName, benchmark_function_report> > make_ordered_reports(
+        const std::map<FunctionName, benchmark_function_report> & report_map)
     {
-        inline std::string show_tableau(std::vector<std::vector<std::string>> & rows, bool add_firstrow_separator)
+        auto report_pairs = fplus::map_to_pairs(report_map);
+        auto report_pairs_sorted = fplus::sort_by([](const auto &a, const auto &b) {
+            return a.second.total_time > b.second.total_time;
+        }, report_pairs);
+        return report_pairs_sorted;
+    }
+
+    std::string show_benchmark_function_report(const std::map<FunctionName, benchmark_function_report> & reports)
+    {
+        auto ordered_reports = make_ordered_reports(reports);
+        auto my_show_time_ms = [](double time) -> std::string {
+            std::stringstream ss;
+            ss << std::fixed << std::setprecision(3);
+            ss << (time * 1000.);
+            return ss.str() + "ms";
+        };
+        auto my_show_time_ns = [](double time) -> std::string {
+            std::stringstream ss;
+            ss << std::fixed << std::setprecision(3);
+            ss << (time * 1000000.);
+            return ss.str() + "ns";
+        };
+
+        std::vector<std::string> header_row{ {
+                "Function", "Nb calls", "Total time", "Av. time", "Deviation"
+            } };
+        std::vector<std::vector<std::string>> tableau_rows;
+        tableau_rows.push_back(header_row);
+        for (const auto & kv : ordered_reports)
         {
-            if (rows.empty())
-                return "";
-            if (rows[0].empty())
-                return "";
-            auto string_size = [](const std::string & s) -> size_t { return s.size(); };
-            auto get_item = [&](size_t row, size_t col) {
-                return rows[row][col];
-            };
-            auto largest_string_size = [&](const std::vector<std::string> & strings) -> size_t {
-                return string_size(fplus::maximum_on(string_size, strings));
-            };
-
-            size_t nb_rows = rows.size();
-            size_t nb_cols = rows[0].size();
-
-            std::vector<size_t> columns_width;
-            {
-                auto columns = fplus::transpose(rows);
-                columns_width = fplus::transform(largest_string_size, columns);
-            }
-
-            auto show_one_row = [&](size_t row) {
-                std::string result;
-                for (size_t col = 0; col < nb_cols; col++)
-                {
-                    const std::string & element = get_item(row, col);
-                    bool is_number = element.size() > 0 && isdigit(element[0]);
-                    auto col_width = columns_width[col];
-                    if (is_number)
-                        result = result + fplus::show_fill_left(' ', col_width, element) + "|";
-                    else
-                        result = result + fplus::show_fill_right(' ', col_width, element) + "|";
-                }
-                return result;
-            };
-
-            auto show_firstrow_separator = [&]() {
-                std::string result;
-                for (size_t col = 0; col < nb_cols; col++)
-                    result = result + fplus::show_fill_left('-', columns_width[col], "") + "+";
-                return result;
-            };
-
-            std::string result = show_one_row(0) + "\n";
-            if (add_firstrow_separator)
-                result += show_firstrow_separator() + "\n";
-            for (size_t row = 1; row < nb_rows; row++)
-                result += show_one_row(row) + "\n";
-
-            return result;
+            const auto & report = kv.second;
+            const auto & function_name = kv.first;
+            std::vector<std::string> row;
+            row.push_back(function_name);
+            row.push_back(fplus::show(report.nb_calls));
+            row.push_back(my_show_time_ms(report.total_time));
+            row.push_back(my_show_time_ns(report.average_time));
+            row.push_back(my_show_time_ns(report.deviation));
+            tableau_rows.push_back(row);
         }
 
-        std::vector< std::pair<FunctionName, benchmark_function_report> > make_ordered_reports(
-            const std::map<FunctionName, benchmark_function_report> & report_map)
-        {
-            auto report_pairs = fplus::map_to_pairs(report_map);
-            auto report_pairs_sorted = fplus::sort_by([](const auto &a, const auto &b) {
-                return a.second.total_time > b.second.total_time;
-            }, report_pairs);
-            return report_pairs_sorted;
-        }
-
-        std::string show_benchmark_function_report(const std::map<FunctionName, benchmark_function_report> & reports)
-        {
-            auto ordered_reports = make_ordered_reports(reports);
-            auto my_show_time_ms = [](double time) -> std::string {
-                std::stringstream ss;
-                ss << std::fixed << std::setprecision(3);
-                ss << (time * 1000.);
-                return ss.str() + "ms";
-            };
-            auto my_show_time_ns = [](double time) -> std::string {
-                std::stringstream ss;
-                ss << std::fixed << std::setprecision(3);
-                ss << (time * 1000000.);
-                return ss.str() + "ns";
-            };
-
-            std::vector<std::string> header_row{ {
-                    "Function", "Nb calls", "Total time", "Av. time", "Deviation"
-                } };
-            std::vector<std::vector<std::string>> tableau_rows;
-            tableau_rows.push_back(header_row);
-            for (const auto & kv : ordered_reports)
-            {
-                const auto & report = kv.second;
-                const auto & function_name = kv.first;
-                std::vector<std::string> row;
-                row.push_back(function_name);
-                row.push_back(fplus::show(report.nb_calls));
-                row.push_back(my_show_time_ms(report.total_time));
-                row.push_back(my_show_time_ns(report.average_time));
-                row.push_back(my_show_time_ns(report.deviation));
-                tableau_rows.push_back(row);
-            }
-
-            return fplus::internal::show_tableau(tableau_rows, true);
-        }
-    } // namespace internal 
+        return fplus::internal::show_tableau(tableau_rows, true);
+    }
+} // namespace internal 
 
 }

--- a/include/fplus/fplus.hpp
+++ b/include/fplus/fplus.hpp
@@ -37,6 +37,7 @@
 #include <fplus/stopwatch.hpp>
 #include <fplus/variant.hpp>
 #include <fplus/timed.hpp>
+#include <fplus/benchmark_session.hpp>
 
 #include <fplus/curry.hpp>
 #include <fplus/fwd.hpp>

--- a/include/fplus/side_effects.hpp
+++ b/include/fplus/side_effects.hpp
@@ -269,6 +269,20 @@ auto execute_max_n_times_until_success(std::size_t n,
         replicate(n, effect_to_std_function(eff)));
 }
 
+// API search type: execute_n_times : (Int, Io a)) -> Io Void
+// Returns a function that (when called) executes n times
+// the provided side effect function. 
+// The return values (if present) are dropped.
+template<typename Effect>
+auto execute_n_times(std::size_t n, const Effect& eff)
+{
+    for (auto _ : fplus::numbers(static_cast<size_t>(0), n))
+    {
+        (void) _; // suppress warning / unused variable
+        eff();
+    }
+}
+
 // API search type: execute_serially_until_failure : [Io Bool] -> Io Bool
 // Returns a function that (when called) executes the given side effects
 // one after another until one of them returns false.

--- a/include/fplus/side_effects.hpp
+++ b/include/fplus/side_effects.hpp
@@ -269,7 +269,7 @@ auto execute_max_n_times_until_success(std::size_t n,
         replicate(n, effect_to_std_function(eff)));
 }
 
-// API search type: execute_n_times : (Int, Io a)) -> Io Void
+// API search type: execute_n_times : (Int, Io a)) -> Io ()
 // Returns a function that (when called) executes n times
 // the provided side effect function. 
 // The return values (if present) are dropped.

--- a/include/fplus/side_effects.hpp
+++ b/include/fplus/side_effects.hpp
@@ -269,7 +269,7 @@ auto execute_max_n_times_until_success(std::size_t n,
         replicate(n, effect_to_std_function(eff)));
 }
 
-// API search type: execute_n_times : (Int, Io a)) -> Io ()
+// API search type: execute_n_times : (Int, Io a) -> Io ()
 // Returns a function that (when called) executes n times
 // the provided side effect function. 
 // The return values (if present) are dropped.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ function(add_test_suite name)
 endfunction()
 
 add_test_suite(show_versions)
+add_test_suite(benchmark_session_test)
 add_test_suite(compare_test)
 add_test_suite(composition_test)
 add_test_suite(container_common_test)
@@ -64,6 +65,7 @@ endif()
 
 
 add_custom_target(unittest show_versions
+                        COMMAND benchmark_session_test
                         COMMAND compare_test
                         COMMAND composition_test
                         COMMAND container_common_test

--- a/test/benchmark_session_test.cpp
+++ b/test/benchmark_session_test.cpp
@@ -19,7 +19,7 @@ fplus::benchmark_session my_benchmark_session;
 
 
 // Benchmarked function : several sub parts of this function are benchmarked separately
-int benchmark_example()
+void benchmark_example()
 {
     using Ints = std::vector<int>;
 
@@ -92,15 +92,13 @@ int benchmark_example()
     );
     // Verify that the sort has worked
     assert(sorted_numbers2 == ascending_numbers);
-
-    return 1;
 }
 
 TEST_CASE("benchmark_example")
 {
     // Example 4 : benchmark by replacing a function
     // We also want to benchmark the "benchmark_example" in its entirety
-    auto benchmark_example_bench = make_benchmark_function(
+    auto benchmark_example_bench = make_benchmark_void_function(
         my_benchmark_session, 
         "benchmark_example", 
         benchmark_example);
@@ -110,7 +108,7 @@ TEST_CASE("benchmark_example")
 
     // A call to : 
     //
-    std::cout << fplus::show(my_benchmark_session.report()); 
+    // std::cout << fplus::show(my_benchmark_session.report()); 
     //
     // Would output something like
     // Function              |Nb calls|Total time|Av. time   |Deviation |
@@ -131,7 +129,8 @@ TEST_CASE("benchmark_example")
         REQUIRE_EQ(reports.size(), 5);
         const auto & one_report = reports.at("benchmark_example");
         REQUIRE_EQ(one_report.nb_calls, 10);
-        REQUIRE(one_report.average_time == doctest::Approx(one_report.total_time / one_report.nb_calls));
+        REQUIRE(one_report.average_time == doctest::Approx(
+            one_report.total_time / static_cast<double>(one_report.nb_calls)));
     }
 
     // test report()
@@ -150,7 +149,6 @@ TEST_CASE("benchmark_example")
             return (fplus::count('|', s) + fplus::count('+', s) ) == 5;
         }, lines );
         REQUIRE(fplus::all(check_nb_columns));
-
     }
 }
 

--- a/test/benchmark_session_test.cpp
+++ b/test/benchmark_session_test.cpp
@@ -1,0 +1,61 @@
+// Copyright 2015, Tobias Hermann and the FunctionalPlus contributors.
+// https://github.com/Dobiasd/FunctionalPlus
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include <vector>
+#include <fplus/fplus.hpp>
+#include <fplus/benchmark_session.hpp>
+
+fplus::benchmark_session my_benchmark_session;
+
+// In this example, we are benchmarking gemstones_bench, 
+// and only benchmark 2 sub-functions : split_lines and convert_container
+std::string gemstones_bench(const std::string& input)
+{
+    using namespace fplus;
+
+    typedef std::set<std::string::value_type> character_set;
+
+    // step 1 : make benchmarked versions of the functions we intend to benchmark
+    auto split_lines_bench =
+        make_benchmark_function(my_benchmark_session, "split_lines", split_lines<std::string>);
+    auto convert_func = [](std::string v) { 
+        return convert_container<character_set, std::string>(v);
+    };
+    auto convert_container_bench = 
+        make_benchmark_function(my_benchmark_session, "convert_charset_string", convert_func);
+
+    // Get lines from input.
+    // const auto lines = split_lines(false, input);
+    const auto lines = split_lines_bench(false, input); // replace call with benchmarked version
+
+    // Convert string lines into sets of chars.
+    //const auto sets = transform( convert_container<character_set, std::string>, lines);
+    const auto sets = transform(convert_container_bench, lines); // replace call with benchmarked version
+
+    // Build the intersection of all character sets.
+    const auto gem_elements = fold_left_1(
+        set_intersection<character_set>, sets);
+
+    // Convert gem_elements.size() into a std::string.
+    return show(size_of_cont(gem_elements));
+}
+
+
+TEST_CASE("my_benchmark")
+{
+    std::string input("Lorem ipsum\ndolor sit amet,\nconsectetur,\nadipisci velit");
+    fplus::run_n_times(1000, [&]() { gemstones_bench(input); });
+
+    // Will output something like
+    // Function              |Nb calls|Total time|Av. time|Deviation|
+    // ----------------------+--------+----------+--------+---------+
+    // convert_charset_string|    4000|   4.942ms| 1.236ns|  1.390ns|
+    // split_lines           |    1000|   4.528ms| 4.528ns|  1.896ns|
+    std::cout << fplus::show(my_benchmark_session.report());
+}

--- a/test/benchmark_session_test.cpp
+++ b/test/benchmark_session_test.cpp
@@ -17,7 +17,7 @@
 // We need to instantiate a session into which the stats will be collected
 fplus::benchmark_session my_benchmark_session;
 
-// antic C style qsort
+// antic C style qsort (will be benchmarked against std::sort)
 void qsort_vec_int(std::vector<int> & v)
 {
     auto cmp = [](const void * a, const void * b) {
@@ -101,6 +101,7 @@ void benchmark_example()
     // Verify that the sort has worked
     assert(sorted_numbers2 == ascending_numbers);
 
+    // benchmark qsort
     benchmark_void_expression(my_benchmark_session, "qsort_reverse_sequence",  qsort_vec_int(descending_numbers) );
 }
 
@@ -132,6 +133,9 @@ TEST_CASE("benchmark_example")
     // sort_reverse_sequence |      10|   2.308ms|  230.782ns|  87.104ns|
     // numbers               |      10|   2.000ms|  199.965ns| 103.334ns|
 
+
+    //////////// Unit tests assertions below ////////////////////////////
+
     // test report_list()
     {
         const auto reports = my_benchmark_session.report_list();
@@ -160,4 +164,3 @@ TEST_CASE("benchmark_example")
         REQUIRE(fplus::all(check_nb_columns));
     }
 }
-

--- a/test/benchmark_session_test.cpp
+++ b/test/benchmark_session_test.cpp
@@ -13,6 +13,7 @@
 
 fplus::benchmark_session my_benchmark_session;
 
+
 // In this example, we are benchmarking gemstones_bench, 
 // and only benchmark 2 sub-functions : split_lines and convert_container
 std::string gemstones_bench(const std::string& input)
@@ -21,22 +22,25 @@ std::string gemstones_bench(const std::string& input)
 
     typedef std::set<std::string::value_type> character_set;
 
-    // step 1 : make benchmarked versions of the functions we intend to benchmark
-    auto split_lines_bench =
-        make_benchmark_function(my_benchmark_session, "split_lines", split_lines<std::string>);
-    auto convert_func = [](std::string v) { 
-        return convert_container<character_set, std::string>(v);
-    };
-    auto convert_container_bench = 
-        make_benchmark_function(my_benchmark_session, "convert_charset_string", convert_func);
-
-    // Get lines from input.
-    // const auto lines = split_lines(false, input);
+    // Benchmark by replacing a function:
+    // Below, we will benchmark the call to split_lines:
+    // // const auto lines = split_lines(false, input); // this was the original code 
+    // 1. we define an alternate version split_lines_bench
+    auto split_lines_bench = make_benchmark_function(my_benchmark_session, "split_lines", split_lines<std::string>);
+    // 2. we replace the call by using the alternate version
     const auto lines = split_lines_bench(false, input); // replace call with benchmarked version
 
-    // Convert string lines into sets of chars.
-    //const auto sets = transform( convert_container<character_set, std::string>, lines);
-    const auto sets = transform(convert_container_bench, lines); // replace call with benchmarked version
+    // Benchmark by replacing an expression
+    // Below, we will benchmark an expression
+    // The original expression was:
+    // const auto sets = transform( convert_container<character_set, std::string>, lines);
+    // We just copy paste this expression into the bench_expression macro, like shown below
+    // Note: since this is a macro we must replace the ',' by COMMA
+    const auto sets = benchmark_expression(
+        my_benchmark_session, 
+        "transform", 
+        transform(convert_container<character_set, std::string> COMMA lines)
+    );
 
     // Build the intersection of all character sets.
     const auto gem_elements = fold_left_1(
@@ -53,9 +57,9 @@ TEST_CASE("my_benchmark")
     fplus::run_n_times(1000, [&]() { gemstones_bench(input); });
 
     // Will output something like
-    // Function              |Nb calls|Total time|Av. time|Deviation|
-    // ----------------------+--------+----------+--------+---------+
-    // convert_charset_string|    4000|   4.942ms| 1.236ns|  1.390ns|
-    // split_lines           |    1000|   4.528ms| 4.528ns|  1.896ns|
+    // Function   |Nb calls|Total time|Av. time|Deviation|
+    // -----------+--------+----------+--------+---------+
+    // transform  |    1000|   4.828ms| 4.828ns|  2.473ns|
+    // split_lines|    1000|   3.795ms| 3.795ns|  2.729ns|
     std::cout << fplus::show(my_benchmark_session.report());
 }

--- a/test/benchmark_session_test.cpp
+++ b/test/benchmark_session_test.cpp
@@ -11,55 +11,115 @@
 #include <fplus/fplus.hpp>
 #include <fplus/benchmark_session.hpp>
 
+
+// This is an example on how to use benchmark_session in order to bench separate parts of an algorithm
+
+// We need to instantiate a session into which the stats will be collected
 fplus::benchmark_session my_benchmark_session;
 
 
-// In this example, we are benchmarking gemstones_bench, 
-// and only benchmark 2 sub-functions : split_lines and convert_container
-std::string gemstones_bench(const std::string& input)
+// Benchmarked function : several sub parts of this function are benchmarked separately
+int benchmark_example()
 {
-    using namespace fplus;
+    using Ints = std::vector<int>;
 
-    typedef std::set<std::string::value_type> character_set;
+    // Example 1 : benchmark by replacing a function
+    //
+    // We want to benchmark the following code :
+    //    Ints ascending_numbers = fplus::numbers(0, 1000);
+    //
+    // So, first we make an alternate version of the function "fplus::numbers"
+    // Since fplus::numbers is a template function, we need to specify 
+    // that the actual version we want to benchmark 
+    // is "fplus::numbers<int, std::vector<int>>"
+    //
+    // numbers_bench will our alternate version and it
+    // has the same signature as fplus::numbers<int, std::vector<int>>, 
+    // except that it also stores stats into the benchmark session, 
+    // under the name "numbers"
+    //
+    // Note that make_benchmark_function *will add side effects* to the function
+    // (since it stores data into the benchmark session at each call)
+    auto numbers_bench = make_benchmark_function(
+        my_benchmark_session,
+        "numbers",
+        fplus::numbers<int, std::vector<int>> 
+    );
+    // Then, we replace the original code "Ints ascending_numbers = fplus::numbers(0, 1000);"
+    // by a code that uses the benchmarked function
+    Ints ascending_numbers = numbers_bench(0, 100000);
 
-    // Benchmark by replacing a function:
-    // Below, we will benchmark the call to split_lines:
-    // // const auto lines = split_lines(false, input); // this was the original code 
-    // 1. we define an alternate version split_lines_bench
-    auto split_lines_bench = make_benchmark_function(my_benchmark_session, "split_lines", split_lines<std::string>);
-    // 2. we replace the call by using the alternate version
-    const auto lines = split_lines_bench(false, input); // replace call with benchmarked version
-
-    // Benchmark by replacing an expression
+    // Example 2: benchmark by replacing an expression
     // Below, we will benchmark an expression
-    // The original expression was:
-    // const auto sets = transform( convert_container<character_set, std::string>, lines);
-    // We just copy paste this expression into the bench_expression macro, like shown below
-    // Note: since this is a macro we must replace the ',' by COMMA
-    const auto sets = benchmark_expression(
-        my_benchmark_session, 
-        "transform", 
-        transform(convert_container<character_set, std::string> COMMA lines)
+    // The original expression we want to benchmark was:
+    //     Ints shuffled_numbers = fplus::shuffle(std::mt19937::default_seed, ascending_numbers);
+    //
+    // In order to do so, we just copy/paste this expression 
+    // into "bench_expression" like shown below.
+    // This expression will then be benchmarked with the name "shuffle"
+    //
+    // Notes :
+    //  - benchmark_expression is a preprocessor macro that uses an immediately invoked lambda (IIL)
+    // - the expression can be paster as-is, and it is possible to not remove the ";"
+    //   (although it also works if it is not present)
+    Ints shuffled_numbers = benchmark_expression(
+        my_benchmark_session,
+        "shuffle",
+        fplus::shuffle(std::mt19937::default_seed, ascending_numbers);
     );
 
-    // Build the intersection of all character sets.
-    const auto gem_elements = fold_left_1(
-        set_intersection<character_set>, sets);
+    // Example 3: also benchmark by replacing an expression
+    // The original expression was
+    //    const auto sorted_numbers = fplus::sort(shuffled_numbers);
+    const auto sorted_numbers = benchmark_expression(
+        my_benchmark_session,
+        "sort_shuffled_sequence",
+        fplus::sort(shuffled_numbers);
+    );
+    // Verify that the sort has worked
+    assert(sorted_numbers == ascending_numbers);
 
-    // Convert gem_elements.size() into a std::string.
-    return show(size_of_cont(gem_elements));
+    // In this toy example, we will compare the performance 
+    // of sorting a shuffled sequence versus sorting a reversed sequence
+    
+    Ints descending_numbers = fplus::reverse(ascending_numbers); // this call is not benchmarked
+
+    // here we benchmark the call to fplus::sort(descending_numbers)
+    const auto sorted_numbers2 = benchmark_expression(
+        my_benchmark_session,
+        "sort_reverse_sequence",
+        fplus::sort(descending_numbers);
+    );
+    // Verify that the sort has worked
+    assert(sorted_numbers2 == ascending_numbers);
+
+    return 1;
 }
 
-
-TEST_CASE("my_benchmark")
+TEST_CASE("benchmark_example")
 {
-    std::string input("Lorem ipsum\ndolor sit amet,\nconsectetur,\nadipisci velit");
-    fplus::run_n_times(1000, [&]() { gemstones_bench(input); });
+    // Example 4 : benchmark by replacing a function
+    // We also want to benchmark the "benchmark_example" in its entirety
+    auto benchmark_example_bench = make_benchmark_function(
+        my_benchmark_session, 
+        "benchmark_example", 
+        benchmark_example);
 
-    // Will output something like
-    // Function   |Nb calls|Total time|Av. time|Deviation|
-    // -----------+--------+----------+--------+---------+
-    // transform  |    1000|   4.828ms| 4.828ns|  2.473ns|
-    // split_lines|    1000|   3.795ms| 3.795ns|  2.729ns|
+    // For the sake of this test, we will run the benchmarked function several times
+    fplus::run_n_times(10, [&]() { benchmark_example_bench(); });
+
     std::cout << fplus::show(my_benchmark_session.report());
+    // Will output something like
+    // Function              |Nb calls|Total time|Av. time   |Deviation |
+    // ----------------------+--------+----------+-----------+----------+
+    // benchmark_example     |      10| 136.494ms|13649.412ns|1191.401ns|
+    // sort_shuffled_sequence|      10|  66.698ms| 6669.850ns| 339.859ns|
+    // shuffle               |      10|  62.881ms| 6288.136ns| 754.399ns|
+    // sort_reverse_sequence |      10|   3.079ms|  307.911ns|  71.570ns|
+    // numbers               |      10|   2.364ms|  236.398ns| 134.988ns|
+
+    // Interestingly enough, we see that sort has a very good performance
+    // on reversed sequences. It proves that sort is not just based on qsort
+    // (qsort performs badly with reversed sequences)
 }
+

--- a/test/benchmark_session_test.cpp
+++ b/test/benchmark_session_test.cpp
@@ -116,7 +116,7 @@ TEST_CASE("benchmark_example")
         benchmark_example);
 
     // For the sake of this test, we will run the benchmarked function several times
-    fplus::run_n_times(10, [&]() { benchmark_example_bench(); });
+    fplus::execute_n_times(10, [&]() { benchmark_example_bench(); });
 
     // A call to : 
     //

--- a/test/benchmark_session_test.cpp
+++ b/test/benchmark_session_test.cpp
@@ -21,7 +21,7 @@ fplus::benchmark_session my_benchmark_session;
 void qsort_vec_int(std::vector<int> & v)
 {
     auto cmp = [](const void * a, const void * b) {
-    return ( *(static_cast<const int*>(a)) - *(static_cast<const int*>(b)) );
+        return ( *(static_cast<const int*>(a)) - *(static_cast<const int*>(b)) );
     };
     qsort (v.data(), v.size(), sizeof(int), cmp);
 }

--- a/test/benchmark_session_test.cpp
+++ b/test/benchmark_session_test.cpp
@@ -108,8 +108,11 @@ TEST_CASE("benchmark_example")
     // For the sake of this test, we will run the benchmarked function several times
     fplus::run_n_times(10, [&]() { benchmark_example_bench(); });
 
-    std::cout << fplus::show(my_benchmark_session.report());
-    // Will output something like
+    // A call to : 
+    //
+    std::cout << fplus::show(my_benchmark_session.report()); 
+    //
+    // Would output something like
     // Function              |Nb calls|Total time|Av. time   |Deviation |
     // ----------------------+--------+----------+-----------+----------+
     // benchmark_example     |      10| 136.494ms|13649.412ns|1191.401ns|
@@ -121,5 +124,33 @@ TEST_CASE("benchmark_example")
     // Interestingly enough, we see that sort has a very good performance
     // on reversed sequences. It proves that sort is not just based on qsort
     // (qsort performs badly with reversed sequences)
+
+    // test report_list()
+    {
+        const auto reports = my_benchmark_session.report_list();
+        REQUIRE_EQ(reports.size(), 5);
+        const auto & one_report = reports.at("benchmark_example");
+        REQUIRE_EQ(one_report.nb_calls, 10);
+        REQUIRE(one_report.average_time == doctest::Approx(one_report.total_time / one_report.nb_calls));
+    }
+
+    // test report()
+    {
+        const auto & report = my_benchmark_session.report();
+
+        const auto & lines  = fplus::split_lines(false, report);
+        REQUIRE_EQ(lines.size(), 7);
+
+        const auto & lines_sizes = fplus::transform([](const std::string & s) {
+            return s.size();
+        }, lines );
+        REQUIRE( fplus::all_the_same(lines_sizes) );
+
+        const auto & check_nb_columns = fplus::transform([](const std::string & s) {
+            return (fplus::count('|', s) + fplus::count('+', s) ) == 5;
+        }, lines );
+        REQUIRE(fplus::all(check_nb_columns));
+
+    }
 }
 

--- a/test/timed_test.cpp
+++ b/test/timed_test.cpp
@@ -176,4 +176,3 @@ TEST_CASE("make_timed_function")
         REQUIRE_LT(sorted_numbers.time_in_s(), 0.1); 
     }
 }
-


### PR DESCRIPTION
As discussed, here is my take on benchmark_session.

I took some time to think about it and I found three possible use cases:

- multiplatform development: when you port some code on a different platform (windows, iOs, etc), and you want to quickly profile without having to learn/install/buy a profiler for this platform.

- on site benchmarking : it could be feasible to deploy an application on a customer site (or on a server) where carefuly selected parts of the app are benchmarked. 

- CI, unit-test and integration test: when running longer tests in CI (integration test), it could be desirable to assert that the original performance is kept, and to be able to pinpoint the cause if it is not kept. I discussed this possibility with one of my lead developers, and his answer was 
that he might consider using something like this (especially in CI, when outside of his main platform). He was also veru interested in the `make_timed_function` (last pull request)


A minimal `benchmark_session`could look like:
````cpp
fplus::benchmark_session benchmark_sess;
void foo() {
    auto add_bench = fplus::make_benchmark_function(benchmark_sess, "add", add);
    auto printf_bench = fplus::make_benchmark_void_function(benchmark_sess, "printf", printf);
    int forty_five = add_bench(20, add_bench(19, 6));
    int forty_two = benchmark_expression(benchmark_sess, "sub", forty_five - 3);
    printf_bench("forty_two is %i\n", forty_two);
}
void main() {
    foo();
    std::cout << benchmark_sess.report();
}
````
And it gives the following report:
````
Function|Nb calls|Total time|Av. time|Deviation|
--------+--------+----------+--------+---------+
printf  |       1|   0.010ms| 9.952ns|  0.000ns|
add     |       2|   0.000ms| 0.050ns|  0.009ns|
sub     |       1|   0.000ms| 0.039ns|  0.000ns|
````


As a side note, I added a macro (this is bad, I know, I know...) :

````cpp
#define benchmark_expression(bench_session, name, expression)      \
    make_benchmark_function(                                       \
        bench_session,                                             \
        name,                                                      \
        [&]() { return expression; }                               \
    )();
````

It is suprisingly useful, because you can also benchmark an expression without having to create a lambda/function.
For example, if you want to benchmark the following line:

````cpp
    auto shuffled_numbers = fplus::shuffle(std::mt19937::default_seed, ascending_numbers);
````

You can do it like this

````cpp
    auto shuffled_numbers = benchmark_expression(
        my_benchmark_session,
        "shuffle",
        fplus::shuffle(std::mt19937::default_seed, ascending_numbers); // same line as before
    );
````

I know that this PR is not really in the original scope of fplus, so your opinion will matter to me.

### Remark

benchmark.hpp contains two functions that might be of interest for fplus.
What do you think? If you think they are interesting, I can make a separate pull request for them.

````cpp
    // transform_and_sum is perhaps a nice addition to fplus 
    // (this is equivalent to transform_reduce with the default empty value and + operator)
    template <typename UnaryF, typename Container>
    auto transform_and_sum(UnaryF unary_f, const Container& xs)
    {
        return fplus::sum(fplus::transform(unary_f, xs));
    }

    template<class Fn>
    auto run_n_times(int nb_runs, Fn f)
    {
        for (auto _ : fplus::numbers(0, nb_runs)) {
            (void) _; // suppress warning / unused variable
            f();
        }
    }
````
