### PR TITLE
clang 7 & conan 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,13 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 project(FunctionalPlus VERSION 0.2.2)
 
 message(STATUS "===( ${PROJECT_NAME} ${PROJECT_VERSION} )===")
-
 option(FPLUS_USE_TOOLCHAIN "Use compiler flags from an external toolchain" OFF)
 option(FPLUS_BUILD_EXAMPLES "Build examples" ON)
 option(FPLUS_BUILD_UNITTEST "Build unit tests" OFF)
+option(FPLUS_UNITTEST_USE_CONAN "Use conan to get doctest dependency (for unit tests only)" OFF)
 
 message(STATUS "Building Unit Tests ${FPLUS_BUILD_UNITTEST}")
+message(STATUS "Use conan ${FPLUS_UNITTEST_USE_CONAN}")
 message(STATUS "Building examples ${FPLUS_BUILD_EXAMPLES}")
 
 if(NOT FPLUS_USE_TOOLCHAIN)

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -14,3 +14,15 @@ set(COMPILE_OPTIONS -Wall
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+
+####### Specific compiler adjustments
+include(CheckCXXCompilerFlag)
+
+# -Wreturn-std-move was introduced by clang 7:
+# It causes an error at container_common.hpp: 338
+# (sometimes std:move is required, sometimes not, depending on the template type)
+check_cxx_compiler_flag(-Wreturn-std-move compiler-has-warning-return-std-move)
+if (compiler-has-warning-return-std-move)
+  list(APPEND COMPILE_OPTIONS -Wno-return-std-move)
+endif()

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,6 +7,15 @@ class FunctionalPlusConan(ConanFile):
     url = "https://github.com/Dobiasd/FunctionalPlus"
     description = "Functional Programming Library for C++. Write concise and readable C++ code."
     exports_sources = ["include*", "LICENSE"]
+    options = {
+        "build_unittest": [True, False],
+    }
+    default_options = "build_unittest=False",
+    generators = ["cmake"]
+
+    def requirements(self):
+        if self.options.build_unittest:
+            self.requires.add('doctest/1.2.6@bincrafters/stable')
 
     def package(self):
         self.copy("*LICENSE", dst="licenses")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,24 @@
-find_package(doctest CONFIG REQUIRED)
+if (FPLUS_UNITTEST_USE_CONAN)
+  # if using conan for the build, first install doctest via conan:
+  # > cd build/
+  # > conan install .. -obuild_unittest=True
+  # > cmake .. -DFPLUS_BUILD_UNITTEST=ON -DFPLUS_UNITTEST_USE_CONAN=ON
+  include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+  conan_basic_setup()
+else()
+    find_package(doctest CONFIG REQUIRED)
+endif()
 
 function(add_test_suite name)
     add_executable(${name} ${name}.cpp)
     add_test(NAME ${name} COMMAND ${name})
 
     target_compile_options(${name} PRIVATE ${COMPILE_OPTIONS})
-    target_link_libraries(${name} PRIVATE fplus ${CMAKE_THREAD_LIBS_INIT} doctest::doctest)
+    if (FPLUS_UNITTEST_USE_CONAN)
+        target_link_libraries(${name} PRIVATE fplus ${CMAKE_THREAD_LIBS_INIT})
+    else()
+        target_link_libraries(${name} PRIVATE fplus ${CMAKE_THREAD_LIBS_INIT} doctest::doctest)
+    endif()
 endfunction()
 
 add_test_suite(show_versions)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,16 +9,19 @@ else()
     find_package(doctest CONFIG REQUIRED)
 endif()
 
+set(link_libraries fplus ${CMAKE_THREAD_LIBS_INIT})
+if (UNIX)
+    list(APPEND link_libraries stdc++ m)
+endif()
+if (NOT FPLUS_UNITTEST_USE_CONAN)
+    list(APPEND link_libraries doctest::doctest)
+endif()
+
 function(add_test_suite name)
     add_executable(${name} ${name}.cpp)
     add_test(NAME ${name} COMMAND ${name})
-
     target_compile_options(${name} PRIVATE ${COMPILE_OPTIONS})
-    if (FPLUS_UNITTEST_USE_CONAN)
-        target_link_libraries(${name} PRIVATE fplus ${CMAKE_THREAD_LIBS_INIT})
-    else()
-        target_link_libraries(${name} PRIVATE fplus ${CMAKE_THREAD_LIBS_INIT} doctest::doctest)
-    endif()
+    target_link_libraries(${name} PRIVATE ${link_libraries})
 endfunction()
 
 add_test_suite(show_versions)
@@ -115,11 +118,10 @@ add_custom_target(unittest show_versions
                         COMMAND stringtools_cp1253_test
                         COMMAND stringtools_utf8_test
                         COMMAND timed_test
-                        COMMAND transform_test                        
+                        COMMAND transform_test
                         COMMAND tree_test
                         COMMAND udemy_course_test
                         COMMAND variant_test
                         COMMENT "Running unittests\n\n"
                         VERBATIM
                         )
-


### PR DESCRIPTION
Hi,

Here is simple pull request. It adds two small adaptations :

* compatibility with clang 7 : one new warning had to be disabled. Also clang 7 requires to explicetely link the unit tests with -lstdc++ and -lm.
* can install doctest with conan, when building the unit tests : this is disabled by default; and the conanfile.py default behavior is preserved.

