### PR TITLE
conanfile.py : can install doctest from conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,13 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 project(FunctionalPlus VERSION 0.2.2)
 
 message(STATUS "===( ${PROJECT_NAME} ${PROJECT_VERSION} )===")
-
 option(FPLUS_USE_TOOLCHAIN "Use compiler flags from an external toolchain" OFF)
 option(FPLUS_BUILD_EXAMPLES "Build examples" ON)
 option(FPLUS_BUILD_UNITTEST "Build unit tests" OFF)
+option(FPLUS_UNITTEST_USE_CONAN "Use conan to get doctest dependency (for unit tests only)" OFF)
 
 message(STATUS "Building Unit Tests ${FPLUS_BUILD_UNITTEST}")
+message(STATUS "Use conan ${FPLUS_UNITTEST_USE_CONAN}")
 message(STATUS "Building examples ${FPLUS_BUILD_EXAMPLES}")
 
 if(NOT FPLUS_USE_TOOLCHAIN)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,10 +19,22 @@ make
 sudo make install
 ```
 
-Building the tests (optional) requires [doctest](https://github.com/onqtam/doctest). Unit Tests are disabled by default – they are enabled and executed by:
+#### Building the unit tests
 
+Unit Tests are disabled by default. Building the tests (optional) requires [doctest](https://github.com/onqtam/doctest).
+
+First, install the required locales
+````bash
+sudo locale-gen ru_RU
+sudo locale-gen ru_RU.UTF-8
+sudo locale-gen el_GR
+sudo locale-gen el_GR.UTF-8
+sudo localedef -c -i ru_RU -f CP1251 ru_RU.CP1251
+sudo localedef -c -i el_GR -f CP1253 el_GR.CP1253
+````
+
+Then, install doctest:
 ```bash
-# install doctest
 git clone https://github.com/onqtam/doctest
 cd doctest
 git checkout tags/1.2.9
@@ -30,19 +42,32 @@ mkdir -p build && cd build
 cmake ..
 make
 sudo make install
-
-# install locales
-sudo locale-gen ru_RU
-sudo locale-gen ru_RU.UTF-8
-sudo locale-gen el_GR
-sudo locale-gen el_GR.UTF-8
-sudo localedef -c -i ru_RU -f CP1251 ru_RU.CP1251
-sudo localedef -c -i el_GR -f CP1253 el_GR.CP1253
-
-# enable, build and run unittests
-cmake -DFPLUS_BUILD_UNITTEST=ON ..
-make unittest
 ```
+
+Then, compile & run the tests
+````bash
+git clone https://github.com/Dobiasd/FunctionalPlus
+cd FunctionalPlus
+mkdir build
+cd build
+cmake .. -DFPLUS_BUILD_UNITTEST=ON
+make
+make test
+````
+
+As an alternative, doctest global installation can be skipped by using [conan](https://conan.io):
+
+````bash
+# pip install conan # (if conan is not installed)
+git clone https://github.com/Dobiasd/FunctionalPlus
+cd FunctionalPlus
+mkdir build
+cd build
+conan install .. -obuild_unittest=True --build=missing
+cmake .. -DFPLUS_BUILD_UNITTEST=ON -DFPLUS_UNITTEST_USE_CONAN=ON
+make
+make test
+````
 
 
 ### way 2: using [cmake's ExternalProject](https://cmake.org/cmake/help/v3.0/module/ExternalProject.html)

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,6 +7,15 @@ class FunctionalPlusConan(ConanFile):
     url = "https://github.com/Dobiasd/FunctionalPlus"
     description = "Functional Programming Library for C++. Write concise and readable C++ code."
     exports_sources = ["include*", "LICENSE"]
+    options = {
+        "build_unittest": [True, False],
+    }
+    default_options = "build_unittest=False",
+    generators = ["cmake"]
+
+    def requirements(self):
+        if self.options.build_unittest:
+            self.requires.add('doctest/1.2.6@bincrafters/stable')
 
     def package(self):
         self.copy("*LICENSE", dst="licenses")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,27 @@
-find_package(doctest CONFIG REQUIRED)
+if (FPLUS_UNITTEST_USE_CONAN)
+  # if using conan for the build, first install doctest via conan:
+  # > cd build/
+  # > conan install .. -obuild_unittest=True
+  # > cmake .. -DFPLUS_BUILD_UNITTEST=ON -DFPLUS_UNITTEST_USE_CONAN=ON
+  include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+  conan_basic_setup()
+else()
+    find_package(doctest CONFIG REQUIRED)
+endif()
+
+set(link_libraries fplus ${CMAKE_THREAD_LIBS_INIT})
+if (UNIX)
+    list(APPEND link_libraries stdc++ m)
+endif()
+if (NOT FPLUS_UNITTEST_USE_CONAN)
+    list(APPEND link_libraries doctest::doctest)
+endif()
 
 function(add_test_suite name)
     add_executable(${name} ${name}.cpp)
     add_test(NAME ${name} COMMAND ${name})
-
     target_compile_options(${name} PRIVATE ${COMPILE_OPTIONS})
-    target_link_libraries(${name} PRIVATE fplus ${CMAKE_THREAD_LIBS_INIT} doctest::doctest)
+    target_link_libraries(${name} PRIVATE ${link_libraries})
 endfunction()
 
 add_test_suite(show_versions)
@@ -102,11 +118,10 @@ add_custom_target(unittest show_versions
                         COMMAND stringtools_cp1253_test
                         COMMAND stringtools_utf8_test
                         COMMAND timed_test
-                        COMMAND transform_test                        
+                        COMMAND transform_test
                         COMMAND tree_test
                         COMMAND udemy_course_test
                         COMMAND variant_test
                         COMMENT "Running unittests\n\n"
                         VERBATIM
                         )
-


### PR DESCRIPTION
Hello,
This PR adds a new cmake option (FPLUS_UNITTEST_USE_CONAN) that enables
to install doctest via conan.

Usage:
> cd build/
> conan install .. -obuild_unittest=True
> cmake .. -DFPLUS_BUILD_UNITTEST=ON -DFPLUS_UNITTEST_USE_CONAN=ON

By default, the conanfile will *not* intall doctest
(an option 'build_unitest' is required).

Note:
I also had to add two libraries for the link (-lstdc++ and -lm)
May be this is only required for osx (but it does not break the linux build)