### PR TITLE
Enable Std lib workaround for apple only

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
 endif()
 
 set(link_libraries fplus ${CMAKE_THREAD_LIBS_INIT})
-if (UNIX)
+if (APPLE) # see issue #147
     list(APPEND link_libraries stdc++ m)
 endif()
 if (NOT FPLUS_UNITTEST_USE_CONAN)


### PR DESCRIPTION
This limits the standard lib workaround (#147) to apple builds (mac os etc.) only.