### PR TITLE
make concat work with generic containers

### DIFF
--- a/include/fplus/container_common.hpp
+++ b/include/fplus/container_common.hpp
@@ -1166,6 +1166,8 @@ ContainerOut concat(const ContainerIn& xss)
         transform(size_of_cont<typename ContainerIn::value_type>, xss));
     ContainerOut result;
     internal::prepare_container(result, length);
+    using std::begin;
+    using std::end;
     for(const auto& xs : xss)
     {
         result.insert(end(result), begin(xs), end(xs));


### PR DESCRIPTION
Explicitly declare using std::begin and std::end to stop any ambiguous function calls