### PR TITLE
Added osx travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-language: python
-python: 3.6
-
+language: generic
 dist: trusty
 sudo: required
 
 matrix:
     include:
     - os: linux
+      language: python
+      python: 3.6
       compiler: gcc
       env: GCC_VERSION=8
         - CC=gcc-8
@@ -15,7 +15,10 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-8']
+
     - os: linux
+      language: python
+      python: 3.6
       compiler: gcc
       env: GCC_VERSION=7
         - CC=gcc-7
@@ -26,6 +29,8 @@ matrix:
           packages: ['g++-7']
 
     - os: linux
+      language: python
+      python: 3.6
       compiler: gcc
       env: GCC_VERSION=6
         - CC=gcc-6
@@ -36,6 +41,8 @@ matrix:
           packages: ['g++-6']
 
     - os: linux
+      language: python
+      python: 3.6
       compiler: gcc
       env: GCC_VERSION=5
         - CC=gcc-5
@@ -46,6 +53,8 @@ matrix:
           packages: ['g++-5']
 
     - os: linux
+      language: python
+      python: 3.6
       compiler: clang
       env: CLANG_VERSION=7
         - CC=clang-7
@@ -56,6 +65,8 @@ matrix:
           packages: ['clang-7', 'libc++-7-dev', 'libc++abi-7-dev']
 
     - os: linux
+      language: python
+      python: 3.6
       compiler: clang
       env: CLANG_VERSION=6.0 LIBCXX=On
         - CC=clang-6.0
@@ -66,6 +77,8 @@ matrix:
           packages: ['clang-6.0', 'g++-6']
 
     - os: linux
+      language: python
+      python: 3.6
       compiler: clang
       env: CLANG_VERSION=5.0 LIBCXX=On
         - CC=clang-5.0
@@ -76,6 +89,8 @@ matrix:
           packages: ['clang-5.0', 'g++-6']
 
     - os: linux
+      language: python
+      python: 3.6
       compiler: clang
       env: CLANG_VERSION=4.0 LIBCXX=On
         - CC=clang-4.0
@@ -86,6 +101,8 @@ matrix:
           packages: ['clang-4.0', 'g++-6']
 
     - os: linux
+      language: python
+      python: 3.6
       compiler: clang
       env: CLANG_VERSION=3.9 LIBCXX=On
         - CC=clang-3.9
@@ -96,6 +113,8 @@ matrix:
           packages: ['clang-3.9', 'g++-6']
 
     - os: linux
+      language: python
+      python: 3.6
       compiler: clang
       env: CLANG_VERSION=3.8 LIBCXX=On
         - CC=clang-3.8
@@ -105,7 +124,26 @@ matrix:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.8']
           packages: ['clang-3.8', 'g++-6']
 
+    - os: osx
+      osx_image: xcode10
+      env: OSX="On"
+        - CC=clang
+        - CXX=clang++
+
+    - os: osx
+      osx_image: xcode9.4
+      env: OSX="On"
+        - CC=clang
+        - CXX=clang++
+
 before_install:
+  - |
+    if [ "$OSX" == "On" ]; then # force python 3 on OSX
+      sudo rm /usr/local/bin/python
+      sudo ln -s /usr/local/bin/python3 /usr/local/bin/python
+      sudo rm /usr/local/bin/pip
+      sudo ln -s /usr/local/bin/pip3 /usr/local/bin/pip
+    fi
   - git clone https://github.com/onqtam/doctest
   - (cd doctest && git checkout tags/1.2.9 && mkdir -p build && cd build && cmake .. && make && sudo make install)
   - |
@@ -116,13 +154,17 @@ before_install:
     if [ "${CLANG_VERSION}" == "7" ]; then
       export CXXFLAGS="-stdlib=libc++"
     fi
-    if [ ! `locale -a | grep ru_RU.cp1251` ]; then
-      sudo localedef -c -i ru_RU -f CP1251 ru_RU.CP1251
-    fi
-    if [ ! `locale -a | grep el_GR.cp1253` ]; then
-      sudo localedef -c -i el_GR -f CP1253 el_GR.CP1253
+    if [ ! "$OSX" == "On" ]; then
+      if [ ! `locale -a | grep ru_RU.cp1251` ]; then
+        sudo localedef -c -i ru_RU -f CP1251 ru_RU.CP1251
+      fi
+      if [ ! `locale -a | grep el_GR.cp1253` ]; then
+        sudo localedef -c -i el_GR -f CP1253 el_GR.CP1253
+      fi
     fi
   - |
+    python --version
+    pip --version
     pip install conan --upgrade
     pip install conan_package_tools
     conan user

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 ![logo](logo/fplus.png)
 
-[![Build Status Travis](https://travis-ci.org/Dobiasd/FunctionalPlus.svg?branch=master)][travis]
-[![Build Status AppVeyor](https://ci.appveyor.com/api/projects/status/github/dobiasd/FunctionalPlus)][appveyor]
+
+
+[![Build Status Travis](https://travis-ci.org/Dobiasd/FunctionalPlus.svg?branch=master)][travis]&nbsp;&nbsp;Linux & OSX 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+[![Build Status AppVeyor](https://ci.appveyor.com/api/projects/status/github/dobiasd/FunctionalPlus)][appveyor]&nbsp;&nbsp;Windows
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 [![(License Boost 1.0)](https://img.shields.io/badge/license-boost%201.0-blue.svg)][license]
 
 [travis]: https://travis-ci.org/Dobiasd/FunctionalPlus
 [appveyor]: https://ci.appveyor.com/project/Dobiasd/functionalplus
 [license]: http://www.boost.org/LICENSE_1_0.txt
-
 
 FunctionalPlus
 ==============

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 ![logo](logo/fplus.png)
 
-
-
-[![Build Status Travis](https://travis-ci.org/Dobiasd/FunctionalPlus.svg?branch=master)][travis]&nbsp;&nbsp;Linux & OSX 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-[![Build Status AppVeyor](https://ci.appveyor.com/api/projects/status/github/dobiasd/FunctionalPlus)][appveyor]&nbsp;&nbsp;Windows
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+[![Build Status Travis](https://travis-ci.org/Dobiasd/FunctionalPlus.svg?branch=master)][travis]
+[![Build Status AppVeyor](https://ci.appveyor.com/api/projects/status/github/dobiasd/FunctionalPlus)][appveyor]
 [![(License Boost 1.0)](https://img.shields.io/badge/license-boost%201.0-blue.svg)][license]
 
 [travis]: https://travis-ci.org/Dobiasd/FunctionalPlus
 [appveyor]: https://ci.appveyor.com/project/Dobiasd/functionalplus
 [license]: http://www.boost.org/LICENSE_1_0.txt
+
 
 FunctionalPlus
 ==============
@@ -353,7 +350,11 @@ When using FunctionalPlus on the other hand you work with normal STL-containers.
 Requirements and Installation
 -----------------------------
 
-A **C++14**-compatible compiler is needed. Compilers from these versions on are fine: GCC 4.9, Clang 3.7 (libc++ 3.7) and Visual C++ 2015.
+A **C++14**-compatible compiler is needed. Compilers from these versions on are fine:
+* GCC ( >= 4.9 )
+* Clang ( >= 3.7 with libc++ >= 3.7 )
+* Visual Studio ( >= 2015 )
+* XCode ( >= 9 )
 
 Guides for different ways to install FunctionalPlus can be found in [INSTALL.md](INSTALL.md).
 

--- a/test/stringtools_cp1253_test.cpp
+++ b/test/stringtools_cp1253_test.cpp
@@ -14,8 +14,10 @@ TEST_CASE("stringtools_test, to_lower/upper_case, cp1253")
 {
     using namespace fplus;
     const std::locale loc = get_locale(
-#ifdef WIN32
+#if defined(WIN32)
         "el-GR"
+#elif defined(__APPLE__)
+        "el_GR.ISO8859-7"
 #else
         "el_GR.cp1253"
 #endif

--- a/test/stringtools_utf8_test.cpp
+++ b/test/stringtools_utf8_test.cpp
@@ -15,7 +15,13 @@ TEST_CASE("stringtools_test, to_lower/upper_case, utf8")
 {
 #ifndef _MSC_VER // FATAL ERROR: Couldn't acquire locale: bad locale name. Is 'ru_RU.utf8' supported on your system?
     using namespace fplus;
-    const std::locale loc = get_locale("ru_RU.utf8");
+    const std::locale loc = get_locale(
+#ifndef __APPLE__
+        "ru_RU.utf8"
+#else
+        "ru_RU.UTF-8"
+#endif
+    );
     auto lower = fwd::to_lower_case_loc(loc);
     auto upper = fwd::to_upper_case_loc(loc);
     REQUIRE_EQ(lower(std::wstring(L"cYrIlLiC 123&? КиРиЛлИцА")), std::wstring(L"cyrillic 123&? кириллица"));
@@ -23,7 +29,7 @@ TEST_CASE("stringtools_test, to_lower/upper_case, utf8")
 
     REQUIRE_EQ(upper(std::wstring(L"cYrIlLiC 123&? КиРиЛлИцА")), std::wstring(L"CYRILLIC 123&? КИРИЛЛИЦА"));
     REQUIRE_EQ(upper(std::wstring(L"абвгдеёжзийклмнопрстуфхцчшщъыьэюя")), std::wstring(L"АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ"));
-    
+
     REQUIRE_EQ(lower(std::wstring(L"GrEeCe 123&? ΕλΛαΔα")), std::wstring(L"greece 123&? ελλαδα"));
     REQUIRE_EQ(lower(std::wstring(L"ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ")), std::wstring(L"αβγδεζηθικλμνξοπρστυφχψω"));
 


### PR DESCRIPTION
cf https://github.com/Dobiasd/FunctionalPlus/issues/147

Hi,

This PR adds two new builders to the travis matrix (xcode 9 and xcode 10)

I had to fight hard against travis inconsistencies, since python support is different on osx.

Details :
* locale tests adapted to osx (different locale names) 
* I had to reduce the timed_test.cpp expectations under osx, since these builders are very slow with travis
* I modified the badges on the readme file, but this commit can be reversed if desired

Thanks