### PR TITLE
Travis Bionic and Clang 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: generic
 
-dist: xenial
+dist: bionic
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,20 @@ matrix:
       language: python
       python: 3.6
       compiler: clang
+      env: CLANG_VERSION=9
+        - CC=clang-9
+        - CXX=clang++-9
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages: ['clang-9', 'libc++-9-dev', 'libc++abi-9-dev']
+
+    - os: linux
+      language: python
+      python: 3.6
+      compiler: clang
       env: CLANG_VERSION=8
         - CC=clang-8
         - CXX=clang++-8
@@ -143,7 +157,6 @@ before_install:
       ./cmake/install_libcxx.sh
     fi
     if [ -n "${CLANG_VERSION}" ]; then
-      echo "=== Using libc++ ==="
       export CXXFLAGS="-stdlib=libc++"
     fi
     if [ ! "$OSX" == "On" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ matrix:
         - CXX=g++-9
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-9']
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
 
     - os: linux
       language: python
@@ -25,7 +26,6 @@ matrix:
         - CXX=g++-8
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-8']
 
     - os: linux
@@ -37,7 +37,6 @@ matrix:
         - CXX=g++-7
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-7']
 
     - os: linux
@@ -49,7 +48,6 @@ matrix:
         - CXX=g++-6
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-6']
 
     - os: linux
@@ -61,7 +59,6 @@ matrix:
         - CXX=g++-5
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-5']
 
     - os: linux
@@ -73,7 +70,6 @@ matrix:
         - CXX=clang++-8
       addons:
         apt:
-          sources: ['llvm-toolchain-xenial', 'llvm-toolchain-xenial-8', 'ubuntu-toolchain-r-test']
           packages: ['clang-8', 'libc++-8-dev', 'libc++abi-8-dev']
 
     - os: linux
@@ -85,7 +81,6 @@ matrix:
         - CXX=clang++-7
       addons:
         apt:
-          sources: ['llvm-toolchain-xenial', 'llvm-toolchain-xenial-7', 'ubuntu-toolchain-r-test']
           packages: ['clang-7', 'libc++-7-dev', 'libc++abi-7-dev']
 
     - os: linux
@@ -97,7 +92,6 @@ matrix:
         - CXX=clang++-6.0
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-6.0']
           packages: ['clang-6.0', 'g++-6']
 
     - os: linux
@@ -109,7 +103,6 @@ matrix:
         - CXX=clang++-5.0
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-5.0']
           packages: ['clang-5.0', 'g++-6']
 
     - os: linux
@@ -121,32 +114,7 @@ matrix:
         - CXX=clang++-4.0
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
-          packages: ['clang-4.0', 'g++-6']
-
-    - os: linux
-      language: python
-      python: 3.6
-      compiler: clang
-      env: CLANG_VERSION=3.9 LIBCXX=On
-        - CC=clang-3.9
-        - CXX=clang++-3.9
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.9']
-          packages: ['clang-3.9', 'g++-6']
-
-    - os: linux
-      language: python
-      python: 3.6
-      compiler: clang
-      env: CLANG_VERSION=3.8 LIBCXX=On
-        - CC=clang-3.8
-        - CXX=clang++-3.8
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.8']
-          packages: ['clang-3.8', 'g++-6']
+          packages: ['clang-4.0', 'libc++-dev', 'g++-6']
 
     - os: osx
       osx_image: xcode10

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,9 +141,9 @@ before_install:
   - |
     if [ "$LIBCXX" == "On" ]; then
       ./cmake/install_libcxx.sh
-      export CXXFLAGS="-stdlib=libc++"
     fi
-    if [ "${CLANG_VERSION}" == "7" ]; then
+    if [ -n "${CLANG_VERSION}" ]; then
+      echo "=== Using libc++ ==="
       export CXXFLAGS="-stdlib=libc++"
     fi
     if [ ! "$OSX" == "On" ]; then


### PR DESCRIPTION
Some CI Updates:

- Upgrade to Bionic Image
- PPAs cleanup (except GCC 9 and Clang 9, which still need them)
- Latest Clang 9 CI build added
- Clang 3.8 and 3.9 removed due to library (`xlocale.h`) and installation issues; in case they are still needed I can try to get them working again
- All Clang builds use `libc++` now
