### PR TITLE
feat: Nicer usage as CMake subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if(NOT FPLUS_USE_TOOLCHAIN)
 endif()
 
 add_library(fplus INTERFACE)
+add_library(FunctionalPlus::fplus ALIAS fplus)
 target_include_directories(fplus INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
   )


### PR DESCRIPTION
It's nice to provide aliases matching exported target names. Would make https://github.com/Dobiasd/frugally-deep/pull/232 simpler.

For example, see https://gitlab.com/libeigen/eigen/-/blob/9cb8771e9c4a1f44ba59741c9fac495d1872bb25/CMakeLists.txt#L582