### PR TITLE
Add missing header

### DIFF
--- a/include/fplus/maybe.hpp
+++ b/include/fplus/maybe.hpp
@@ -8,6 +8,7 @@
 
 #include <fplus/function_traits.hpp>
 #include <fplus/container_common.hpp>
+#include <fplus/compare.hpp>
 #include <fplus/internal/composition.hpp>
 #include <fplus/internal/asserts/composition.hpp>
 


### PR DESCRIPTION
This is needed so that one can use:
#include <fplus/container_common.hpp>

is_sufix_of(...)

See https://github.com/Dobiasd/FunctionalPlus/issues/185

Also:
Fixes https://github.com/Dobiasd/FunctionalPlus/issues/183