### PR TITLE
Timed variadic refs

### DIFF
--- a/include/fplus/benchmark_session.hpp
+++ b/include/fplus/benchmark_session.hpp
@@ -99,17 +99,17 @@ namespace internal
             , fn_(fn)
         {};
 
-        template<typename ...Args> auto operator()(Args... args)
+        template<typename ...Args> auto operator()(Args&&... args)
         {
-            return _bench_result(args...);
+            return _bench_result(std::forward<Args>(args)...);
         }
 
     private:
         template<typename ...Args>
-        auto _bench_result(Args... args)
+        auto _bench_result(Args&&... args)
         {
             fplus::stopwatch timer;
-            auto r = fn_(args...);
+            auto r = fn_(std::forward<Args>(args)...);
             benchmark_session_.store_one_time(function_name_, timer.elapsed());
             return r;
         }
@@ -132,17 +132,17 @@ namespace internal
             , fn_(fn)
         {};
 
-        template<typename ...Args> auto operator()(Args... args)
+        template<typename ...Args> auto operator()(Args&&... args)
         {
-            _bench_result(args...);
+            _bench_result(std::forward<Args>(args)...);
         }
 
     private:
         template<typename ...Args>
-        auto _bench_result(Args... args)
+        auto _bench_result(Args&&... args)
         {
             fplus::stopwatch timer;
-            fn_(args...);
+            fn_(std::forward<Args>(args)...);
             benchmark_session_.store_one_time(function_name_, timer.elapsed());
         }
 

--- a/include/fplus/timed.hpp
+++ b/include/fplus/timed.hpp
@@ -59,14 +59,17 @@ namespace internal
     {
     public:
         explicit timed_function_impl(Fn fn) : _fn(fn) {};
-        template<typename ...Args> auto operator()(Args... args) { return _timed_result(args...); }
+        template<typename ...Args> auto operator()(Args&&... args) 
+        { 
+            return _timed_result(std::forward<Args>(args)...); 
+        }
 
     private:
         template<typename ...Args>
-        auto _timed_result(Args... args)
+        auto _timed_result(Args&&... args)
         {
             fplus::stopwatch timer;
-            auto r = _fn(args...);
+            auto r = _fn(std::forward<Args>(args)...);
             auto r_t = fplus::timed<decltype(r)>(r, timer.elapsed());
             return r_t;
         }
@@ -102,17 +105,17 @@ namespace internal
     {
     public:
         explicit timed_void_function_impl(Fn fn) : _fn(fn) {};
-        template<typename ...Args> auto operator()(Args... args)
+        template<typename ...Args> auto operator()(Args&&... args)
         {
-            return _timed_result(args...);
+            return _timed_result(std::forward<Args>(args)...);
         }
 
     private:
         template<typename ...Args>
-        auto _timed_result(Args... args)
+        auto _timed_result(Args&&... args)
         {
             fplus::stopwatch timer;
-            _fn(args...);
+            _fn(std::forward<Args>(args)...);
             return timer.elapsed();
         }
 

--- a/include_all_in_one/include/fplus/fplus.hpp
+++ b/include_all_in_one/include/fplus/fplus.hpp
@@ -14255,14 +14255,17 @@ namespace internal
     {
     public:
         explicit timed_function_impl(Fn fn) : _fn(fn) {};
-        template<typename ...Args> auto operator()(Args... args) { return _timed_result(args...); }
+        template<typename ...Args> auto operator()(Args&&... args) 
+        { 
+            return _timed_result(std::forward<Args>(args)...); 
+        }
 
     private:
         template<typename ...Args>
-        auto _timed_result(Args... args)
+        auto _timed_result(Args&&... args)
         {
             fplus::stopwatch timer;
-            auto r = _fn(args...);
+            auto r = _fn(std::forward<Args>(args)...);
             auto r_t = fplus::timed<decltype(r)>(r, timer.elapsed());
             return r_t;
         }
@@ -14298,17 +14301,17 @@ namespace internal
     {
     public:
         explicit timed_void_function_impl(Fn fn) : _fn(fn) {};
-        template<typename ...Args> auto operator()(Args... args)
+        template<typename ...Args> auto operator()(Args&&... args)
         {
-            return _timed_result(args...);
+            return _timed_result(std::forward<Args>(args)...);
         }
 
     private:
         template<typename ...Args>
-        auto _timed_result(Args... args)
+        auto _timed_result(Args&&... args)
         {
             fplus::stopwatch timer;
-            _fn(args...);
+            _fn(std::forward<Args>(args)...);
             return timer.elapsed();
         }
 
@@ -14437,17 +14440,17 @@ namespace internal
             , fn_(fn)
         {};
 
-        template<typename ...Args> auto operator()(Args... args)
+        template<typename ...Args> auto operator()(Args&&... args)
         {
-            return _bench_result(args...);
+            return _bench_result(std::forward<Args>(args)...);
         }
 
     private:
         template<typename ...Args>
-        auto _bench_result(Args... args)
+        auto _bench_result(Args&&... args)
         {
             fplus::stopwatch timer;
-            auto r = fn_(args...);
+            auto r = fn_(std::forward<Args>(args)...);
             benchmark_session_.store_one_time(function_name_, timer.elapsed());
             return r;
         }
@@ -14470,17 +14473,17 @@ namespace internal
             , fn_(fn)
         {};
 
-        template<typename ...Args> auto operator()(Args... args)
+        template<typename ...Args> auto operator()(Args&&... args)
         {
-            _bench_result(args...);
+            _bench_result(std::forward<Args>(args)...);
         }
 
     private:
         template<typename ...Args>
-        auto _bench_result(Args... args)
+        auto _bench_result(Args&&... args)
         {
             fplus::stopwatch timer;
-            fn_(args...);
+            fn_(std::forward<Args>(args)...);
             benchmark_session_.store_one_time(function_name_, timer.elapsed());
         }
 

--- a/test/benchmark_session_test.cpp
+++ b/test/benchmark_session_test.cpp
@@ -103,6 +103,7 @@ void benchmark_example()
 
     // benchmark qsort
     benchmark_void_expression(my_benchmark_session, "qsort_reverse_sequence",  qsort_vec_int(descending_numbers) );
+    REQUIRE(descending_numbers == ascending_numbers);
 }
 
 
@@ -162,5 +163,53 @@ TEST_CASE("benchmark_example")
             return (fplus::count('|', s) + fplus::count('+', s) ) == 5;
         }, lines );
         REQUIRE(fplus::all(check_nb_columns));
+    }
+}
+
+
+//
+// The test below asserts that variadic arguments containing modifiable references are correctly forwarded
+//
+bool function_with_input_output_params(int input1, int& output2)
+{
+    output2 = input1 + 1;
+    return true;
+}
+void void_function_with_input_output_params(int input1, int& output2)
+{
+    output2 = input1 + 1;
+}
+TEST_CASE("benchmark_input_output_args")
+{
+    fplus::benchmark_session benchmark_session;
+
+    // With non void function
+    {
+        auto function_with_input_output_params_bench = make_benchmark_function(
+            my_benchmark_session,
+            "function_with_input_output_params_bench",
+            function_with_input_output_params
+        );
+
+        int input1 = 1;
+        int output2 = 42;
+
+        bool r = function_with_input_output_params_bench(input1, output2);
+        REQUIRE_EQ(output2, 2);
+        REQUIRE(r);
+    }
+    // With void function
+    {
+        auto void_function_with_input_output_params_bench = make_benchmark_void_function(
+            my_benchmark_session,
+            "void_function_with_input_output_params_bench",
+            void_function_with_input_output_params
+        );
+
+        int input1 = 1;
+        int output2 = 42;
+
+        void_function_with_input_output_params_bench(input1, output2);
+        REQUIRE_EQ(output2, 2);
     }
 }

--- a/test/timed_test.cpp
+++ b/test/timed_test.cpp
@@ -178,3 +178,41 @@ TEST_CASE("make_timed_function")
         REQUIRE_LT(sorted_numbers.time_in_s(), 0.1);
     }
 }
+
+
+//
+// The test below asserts that variadic arguments containing modifiable references are correctly forwarded
+//
+bool function_with_input_output_params(int input1, int& output2)
+{
+    output2 = input1 + 1;
+    return true;
+}
+void void_function_with_input_output_params(int input1, int& output2)
+{
+    output2 = input1 + 1;
+}
+TEST_CASE("timed_with_input_output_args")
+{
+    // With non void function
+    {
+        auto timed_function_with_input_output_params = fplus::make_timed_function(function_with_input_output_params);
+
+        int input1 = 1;
+        int output2 = 42;
+
+        fplus::timed<bool> r = timed_function_with_input_output_params(input1, output2);
+        REQUIRE_EQ(output2, 2);
+        REQUIRE(r.get());
+    }
+    // With void function
+    {
+        auto timed_void_function_with_input_output_params = fplus::make_timed_void_function(void_function_with_input_output_params);
+
+        int input1 = 1;
+        int output2 = 42;
+
+        timed_void_function_with_input_output_params(input1, output2);
+        REQUIRE_EQ(output2, 2);
+    }
+}


### PR DESCRIPTION
Hello,

I corrected an issue with timed functions and benchmark session.

Basically if you had a function like this, where the second parameter is an output parameter passed by reference:

````cpp
bool foo(int input1, int& output2)
{
    output2 = input1 + 1;
    return true;
}
````

and 
````
auto foo_timed = make_timed_function(foo);
````

Then `foo_timed(a, b)` would not modify the second parameter...

I corrected this by using universal references + std::forward.

> Side note: 
> The C++ syntax for perfect forwarding variadic arguments makes my eyes bleed :-), sorry if had missed that in the first version
> `template<typename ...Args> auto f1()(Args&&... args) { return f2(std::forward<Args>(args)...;) }`
> (oooh, the subtle dance between "...", "&&" and "(" )
