### PR TITLE
CMake install tweaks

### DIFF
--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -71,4 +71,10 @@ install(
     COMPONENT "${fplus_component}"
 )
 
+# Conditionally include the CPack module only if this is the top project, so
+# appropriate targets and files are generated for packaging the library
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  include(CPack)
+endif()
+
 # }

--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -41,11 +41,16 @@ install(
     INCLUDES DESTINATION "${include_install_dir}"
 )
 
+# Dev component name, useful if the client embeds the library into their build
+# tree and want to install only their own files
+set(fplus_component "${PROJECT_NAME}_Development")
+
 # Headers:
 #   * include/fplus/fplus.hpp -> ${CMAKE_INSTALL_INCLUDEDIR}/fplus/fplus.hpp
 install(
     DIRECTORY "include/fplus" # no trailing slash
     DESTINATION "${include_install_dir}"
+    COMPONENT "${fplus_component}"
 )
 
 # Config
@@ -54,6 +59,7 @@ install(
 install(
     FILES "${project_config}" "${version_config}"
     DESTINATION "${config_install_dir}"
+    COMPONENT "${fplus_component}"
 )
 
 # Config
@@ -62,6 +68,7 @@ install(
     EXPORT "${TARGETS_EXPORT_NAME}"
     NAMESPACE "${namespace}"
     DESTINATION "${config_install_dir}"
+    COMPONENT "${fplus_component}"
 )
 
 # }


### PR DESCRIPTION
This contains two Quality of Life improvements:
* Every `install` command that puts files on the filesystem during install now has an associated component with the `${PROJECT_NAME}_Development` naming convention, so they no longer get associated to the default `Unspecified` component.
* If the library is configured as the top level one, the `CPack` module is loaded, which generates `cpack` related files and targets for easy packaging.
```bash
cmake -S . -B build
# no build step, header only project
sudo cmake --install build --component FunctionalPlus_Development
(cd build; cpack -G DEB -D CPACK_PACKAGE_CONTACT=example@example.com)
# FunctionalPlus-0.2.13-Linux.deb generated in build dir, ready to distribute
```
After this PR, I can certainly say that the project could be shown around as doing everything right regarding CMake.