### PR TITLE
Use build requirement for tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,7 +73,7 @@ foreach(name IN LISTS tests)
       FunctionalPlus::fplus
       doctest::doctest
   )
-  target_compile_features("${name}" INTERFACE cxx_std_14)
+  target_compile_features("${name}" PRIVATE cxx_std_14)
   doctest_discover_tests("${name}")
 endforeach()
 


### PR DESCRIPTION
INTERFACE defines usage requirements.

I'll chalk this up to being a copy-paste error.