### PR TITLE
Control doctest from CMake

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,6 +67,11 @@ set(
 foreach(name IN LISTS tests)
   add_executable("${name}" "${name}.cpp")
   target_compile_options("${name}" PRIVATE ${project_warnings})
+  target_compile_definitions(
+      "${name}"
+      PRIVATE
+      DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+  )
   target_link_libraries(
       "${name}"
       PRIVATE

--- a/test/benchmark_session_test.cpp
+++ b/test/benchmark_session_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 
 #include <vector>

--- a/test/benchmark_session_test.cpp
+++ b/test/benchmark_session_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 
 #include <vector>
 #include <fplus/fplus.hpp>

--- a/test/compare_test.cpp
+++ b/test/compare_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/compare_test.cpp
+++ b/test/compare_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/composition_test.cpp
+++ b/test/composition_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/composition_test.cpp
+++ b/test/composition_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/container_common_test.cpp
+++ b/test/container_common_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/container_common_test.cpp
+++ b/test/container_common_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 #include <deque>

--- a/test/container_properties_test.cpp
+++ b/test/container_properties_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/container_properties_test.cpp
+++ b/test/container_properties_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/container_traits_test.cpp
+++ b/test/container_traits_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 TEST_CASE("container_traits_test, static_asserts")

--- a/test/container_traits_test.cpp
+++ b/test/container_traits_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/curry_test.cpp
+++ b/test/curry_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/curry_test.cpp
+++ b/test/curry_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 namespace {

--- a/test/extrapolate_test.cpp
+++ b/test/extrapolate_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/extrapolate_test.cpp
+++ b/test/extrapolate_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/function_traits_test.cpp
+++ b/test/function_traits_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/function_traits_test.cpp
+++ b/test/function_traits_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/fwd_test.cpp
+++ b/test/fwd_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/fwd_test.cpp
+++ b/test/fwd_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 namespace {

--- a/test/generate_test.cpp
+++ b/test/generate_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 #include <utility>

--- a/test/generate_test.cpp
+++ b/test/generate_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/interpolate_test.cpp
+++ b/test/interpolate_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/interpolate_test.cpp
+++ b/test/interpolate_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/invoke_test.cpp
+++ b/test/invoke_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <functional>
 #include <fplus/internal/invoke.hpp>

--- a/test/invoke_test.cpp
+++ b/test/invoke_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <functional>
 #include <fplus/internal/invoke.hpp>
 

--- a/test/maps_test.cpp
+++ b/test/maps_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/maps_test.cpp
+++ b/test/maps_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/maybe_test.cpp
+++ b/test/maybe_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/maybe_test.cpp
+++ b/test/maybe_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/numeric_test.cpp
+++ b/test/numeric_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/numeric_test.cpp
+++ b/test/numeric_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/optimize_test.cpp
+++ b/test/optimize_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <array>
 

--- a/test/optimize_test.cpp
+++ b/test/optimize_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <array>

--- a/test/pairs_test.cpp
+++ b/test/pairs_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/pairs_test.cpp
+++ b/test/pairs_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 namespace {

--- a/test/queue_test.cpp
+++ b/test/queue_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 TEST_CASE("queue_test, full")

--- a/test/queue_test.cpp
+++ b/test/queue_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/raii_test.cpp
+++ b/test/raii_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/raii_test.cpp
+++ b/test/raii_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 TEST_CASE("raii_test, make_raii")

--- a/test/read_test.cpp
+++ b/test/read_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/read_test.cpp
+++ b/test/read_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/readme_examples_test.cpp
+++ b/test/readme_examples_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/readme_examples_test.cpp
+++ b/test/readme_examples_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/replace_test.cpp
+++ b/test/replace_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/replace_test.cpp
+++ b/test/replace_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 #include <string>

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/search_test.cpp
+++ b/test/search_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/search_test.cpp
+++ b/test/search_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/sets_test.cpp
+++ b/test/sets_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 

--- a/test/sets_test.cpp
+++ b/test/sets_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/shared_ref_test.cpp
+++ b/test/shared_ref_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/shared_ref_test.cpp
+++ b/test/shared_ref_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 namespace

--- a/test/show_test.cpp
+++ b/test/show_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/show_test.cpp
+++ b/test/show_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 namespace {

--- a/test/show_versions.cpp
+++ b/test/show_versions.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/show_versions.cpp
+++ b/test/show_versions.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 TEST_CASE("show_versions, print_defines")

--- a/test/side_effects_test.cpp
+++ b/test/side_effects_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/side_effects_test.cpp
+++ b/test/side_effects_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/split_test.cpp
+++ b/test/split_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/split_test.cpp
+++ b/test/split_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 namespace {

--- a/test/stopwatch_test.cpp
+++ b/test/stopwatch_test.cpp
@@ -1,7 +1,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <fplus/stopwatch.hpp>

--- a/test/stopwatch_test.cpp
+++ b/test/stopwatch_test.cpp
@@ -1,7 +1,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <fplus/stopwatch.hpp>
 

--- a/test/stringtools_cp1251_test.cpp
+++ b/test/stringtools_cp1251_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <fplus/fwd.hpp>
 #include "get_locale.hpp"

--- a/test/stringtools_cp1251_test.cpp
+++ b/test/stringtools_cp1251_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <fplus/fwd.hpp>

--- a/test/stringtools_cp1253_test.cpp
+++ b/test/stringtools_cp1253_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <fplus/fwd.hpp>
 #include "get_locale.hpp"

--- a/test/stringtools_cp1253_test.cpp
+++ b/test/stringtools_cp1253_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <fplus/fwd.hpp>

--- a/test/stringtools_test.cpp
+++ b/test/stringtools_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/stringtools_test.cpp
+++ b/test/stringtools_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/stringtools_utf8_test.cpp
+++ b/test/stringtools_utf8_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <fplus/fwd.hpp>
 #include "get_locale.hpp"

--- a/test/stringtools_utf8_test.cpp
+++ b/test/stringtools_utf8_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <fplus/fwd.hpp>

--- a/test/timed_test.cpp
+++ b/test/timed_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 
 #include <vector>
 #include <cmath>

--- a/test/timed_test.cpp
+++ b/test/timed_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 
 #include <vector>

--- a/test/transform_test.cpp
+++ b/test/transform_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/transform_test.cpp
+++ b/test/transform_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 namespace {

--- a/test/tree_test.cpp
+++ b/test/tree_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 

--- a/test/tree_test.cpp
+++ b/test/tree_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/udemy_course_test.cpp
+++ b/test/udemy_course_test.cpp
@@ -9,7 +9,6 @@
 // "Functional Programming using C++"
 // https://www.udemy.com/functional-programming-using-cpp/
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 #include <vector>

--- a/test/udemy_course_test.cpp
+++ b/test/udemy_course_test.cpp
@@ -9,7 +9,7 @@
 // "Functional Programming using C++"
 // https://www.udemy.com/functional-programming-using-cpp/
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 #include <vector>
 

--- a/test/variant_test.cpp
+++ b/test/variant_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 #include <fplus/fplus.hpp>
 

--- a/test/variant_test.cpp
+++ b/test/variant_test.cpp
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
 
 namespace {


### PR DESCRIPTION
This PR moves config definition for the `main()` implementation from the source files into the tests' lists file.

While I was there, I also corrected the doctest includes to better align with the [core guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rs-incform).