### PR TITLE
Add customization point for config location

### DIFF
--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -29,23 +29,30 @@ write_basic_package_version_file(
 )
 
 # Location of the CMake package that find_package() can find
-set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/FunctionalPlus")
+set(
+    FunctionalPlus_INSTALL_CMAKEDIR
+    "${CMAKE_INSTALL_LIBDIR}/cmake/FunctionalPlus"
+    CACHE STRING "CMake package config location relative to the install prefix"
+)
+
+# This variable is a customization point for package managers like vcpkg
+mark_as_advanced(FunctionalPlus_INSTALL_CMAKEDIR)
 
 install(
     FILES
     "${PROJECT_SOURCE_DIR}/cmake/FunctionalPlusConfig.cmake"
     "${PROJECT_BINARY_DIR}/FunctionalPlusConfigVersion.cmake"
-    DESTINATION "${config_install_dir}"
+    DESTINATION "${FunctionalPlus_INSTALL_CMAKEDIR}"
     COMPONENT "${fplus_component}"
 )
 
-# Generate the FunctionalPlusTargets.cmake file in the config_install_dir that
-# is included by FunctionalPlusConfig.cmake after the dependencies have been
-# found
+# Generate the FunctionalPlusTargets.cmake file in the
+# FunctionalPlus_INSTALL_CMAKEDIR that is included by
+# FunctionalPlusConfig.cmake after the dependencies have been found
 install(
     EXPORT FunctionalPlusTargets
     NAMESPACE FunctionalPlus::
-    DESTINATION "${config_install_dir}"
+    DESTINATION "${FunctionalPlus_INSTALL_CMAKEDIR}"
     COMPONENT "${fplus_component}"
 )
 


### PR DESCRIPTION
This cache variable allows package managers to customize the CMake config location according to their own conventions.

After a short discussion with @ras0219-msft, I was convinced that the config location should be a cache variable.  
For regular users, this will not change anything.  
For package managers and their maintainers, this means they can move the files to some intermediate location for processing, then finally in some other location that `find_package()` can find, if they so wish.