### PR TITLE
GCC 11 and Clang 12 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         build_config:
+          - { version: 11 }
           - { version: 10 }
           - { version: 9 }
           - { version: 8 }
@@ -36,6 +37,7 @@ jobs:
     strategy:
       matrix:
         build_config:
+          - { version: 12 }
           - { version: 11 }
           - { version: 10 }
           - { version: 9 }


### PR DESCRIPTION
CI build for the latest versions of GCC and Clang.