### PR TITLE
Update CodeQL to v2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: sudo script/ci_setup_dependencies.sh
       - name: CodeQL Initialization
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: cpp
           queries: +security-and-quality
@@ -28,4 +28,4 @@ jobs:
           cmake -S test -B build
           cmake --build build -j 4
       - name: CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
CodeQL v2 is available, therefore v1 is scheduled for deprecation at the end of the year.

Not much to change though :smile: .

https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/