### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -217,3 +217,15 @@ You can also use this standalone header on [Compiler Explorer](https://godbolt.o
 ````cpp
 #include "https://raw.githubusercontent.com/Dobiasd/FunctionalPlus/master/include_all_in_one/include/fplus/fplus.hpp"
 ````
+
+### way 10: using [vcpkg](https://github.com/Microsoft/vcpkg)
+
+You can download and install FunctionalPlus using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install fplus
+
+The fplus port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,18 @@ Output:
 
 The functions shown not only work with default STL containers like `std::vector`, `std::list`, `std::deque`, `std::string` etc., but also with custom containers providing a similar interface.
 
+Package Managers
+----------------
+
+You can download and install FunctionalPlus using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install fplus
+
+The fplus port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 Type deduction and useful error messages
 ----------------------------------------

--- a/README.md
+++ b/README.md
@@ -196,19 +196,6 @@ Output:
 
 The functions shown not only work with default STL containers like `std::vector`, `std::list`, `std::deque`, `std::string` etc., but also with custom containers providing a similar interface.
 
-Package Managers
-----------------
-
-You can download and install FunctionalPlus using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install fplus
-
-The fplus port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
-
 Type deduction and useful error messages
 ----------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Output:
 
 The functions shown not only work with default STL containers like `std::vector`, `std::list`, `std::deque`, `std::string` etc., but also with custom containers providing a similar interface.
 
+
 Type deduction and useful error messages
 ----------------------------------------
 


### PR DESCRIPTION
`fplus `is available as a port in vcpkg, a C++ library manager that simplifies installation for `fplus `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build fplus, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/fplus/portfile.cmake). We try to keep the library maintained as close as possible to the original library.