### PR TITLE
Clang 15 build and Doctest update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [workflow_dispatch, push, pull_request]
 
 jobs:
   build_gcc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         build_config:
@@ -34,7 +34,7 @@ jobs:
 
 
   build_clang:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         build_config:
@@ -79,7 +79,7 @@ jobs:
 
 
   build_osx:
-    runs-on: macos-11.0
+    runs-on: macos-latest
     name: "OS X"
     env:
       CC: clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
     strategy:
       matrix:
         build_config:
+          - { version: 15 }
           - { version: 14 }
           - { version: 13 }
           - { version: 12 }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   codeql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: "CodeQL"
     env:
       CC: gcc-10

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,11 +33,11 @@ see [FetchContent](#way-3-using-cmake-314-fetchcontent) or
 #### Building the unit tests
 
 Unit Tests are available from a separate CMakeLists.txt file. Building the
-tests requires [doctest](https://github.com/onqtam/doctest).
+tests requires [doctest](https://github.com/doctest/doctest).
 
 Install doctest:
 ```bash
-git clone --depth=1 --branch=2.4.5 https://github.com/onqtam/doctest # 2.4.6 has a bug, see https://github.com/Dobiasd/FunctionalPlus/issues/250
+git clone --depth=1 --branch=v2.4.9 https://github.com/doctest/doctest
 cmake -S doctest -B doctest/build -DDOCTEST_WITH_TESTS=OFF -DDOCTEST_WITH_MAIN_IN_STATIC_LIB=OFF
 cmake --build doctest/build -j 4
 sudo cmake --install doctest/build
@@ -55,7 +55,7 @@ As an alternative, doctest global installation can be skipped by installing to
 a local prefix:
 
 ````bash
-git clone --depth=1 --branch=2.4.5 https://github.com/onqtam/doctest
+git clone --depth=1 --branch=v2.4.9 https://github.com/doctest/doctest
 cmake -S doctest -B doctest/build -DDOCTEST_WITH_TESTS=OFF -DDOCTEST_WITH_MAIN_IN_STATIC_LIB=OFF
 cmake --build doctest/build
 cmake --install doctest/build --prefix doctest

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-doctest/2.4.5
+doctest/2.4.9
 
 [generators]
 cmake_find_package

--- a/script/ci_setup_dependencies.sh
+++ b/script/ci_setup_dependencies.sh
@@ -2,7 +2,7 @@
 
 
 ## Install doctest
-git clone --depth=1 --branch=2.4.5 https://github.com/onqtam/doctest
+git clone --depth=1 --branch=v2.4.9 https://github.com/doctest/doctest
 cd doctest && mkdir -p build && cd build
 cmake .. -DDOCTEST_WITH_TESTS=OFF -DDOCTEST_WITH_MAIN_IN_STATIC_LIB=OFF
 cmake --build . --config Release --target install

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,7 @@ set(
 include(../cmake/root-project.cmake)
 include(../cmake/warnings.cmake)
 
-find_package(doctest 2.4.5 CONFIG REQUIRED)
+find_package(doctest 2.4.9 CONFIG REQUIRED)
 # for doctest_discover_tests
 include(doctest)
 


### PR DESCRIPTION
Clang 15 CI build and update of Doctest to it's latest version; Clang 15 reported warnings on the old version.

This PR includes an update of Action runners to `latest` and doctest url.