### PR TITLE
Clang 16 CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
     strategy:
       matrix:
         build_config:
+          - { version: 16 }
           - { version: 15 }
           - { version: 14 }
           - { version: 13 }

--- a/test/container_common_test.cpp
+++ b/test/container_common_test.cpp
@@ -661,7 +661,7 @@ TEST_CASE("container_common_test - coucount_occurrences_bynt_occurrences_on")
     typedef std::map<int, std::size_t> IntSizeTMap;
     IntSizeTMap OccurrencesResult = {{1, 1}, {2, 3}, {3, 1}};
     std::vector<double> double_values = {1.1, 2.3, 2.7, 3.6, 2.4};
-    const auto f = floor<double>;
+    const auto f = fplus::floor<double>;
     REQUIRE_EQ(count_occurrences_by(f, double_values), OccurrencesResult);
 }
 


### PR DESCRIPTION
Adds a CI build for latest Clang 16.

There's a compile error with this version (#273) which needs get fixed before merging this PR.

closes #273 