### PR TITLE
Fixes for auto_generate

### DIFF
--- a/generate/auto_generate.py
+++ b/generate/auto_generate.py
@@ -29,6 +29,10 @@ def fread_lines(filename):
     """
     Python 2 & 3 agnostic fopen + readlines
     """
+    if not os.path.exists(filename):
+        # Safe escape after running clean.
+        return ""
+        
     if version_info[0] >= 3:
         f = open(filename, "r", encoding='utf-8', errors='ignore')
     else:
@@ -53,9 +57,10 @@ def fwrite_content(filename, content):
     This function will not overwrite the file (and thus not update its modification date) 
     if the new content is unchanged
     """
-    old_content = fread_content(filename)
-    if old_content == content:
-        return
+    if os.path.exists(filename):
+        old_content = fread_content(filename)
+        if old_content == content:
+            return
 
     if version_info[0] >= 3:
         f = open(filename, "w", encoding='utf-8', errors='ignore')


### PR DESCRIPTION
I got the following error when running `ninja` after doing `ninja clean`.  It appears that CMake is deleting the generated files when doing a clean because they are byproducts in the `auto_generate` target.  I have included patches to the auto generate step to allow it to continue even when files are missing.

```
vscode ➜ /workspaces/project/build (master) $ ninja
[0/2] Re-checking globbed directories...
[2/323] cd /workspaces/project/build/third_party/FunctionalPlus && /usr...workspaces/project/third_party/FunctionalPlus/generate/auto_generate.py
FAILED: third_party/FunctionalPlus/CMakeFiles/auto_generate ../third_party/FunctionalPlus/include/fplus/fwd_instances.autogenerated_defines ../third_party/FunctionalPlus/include/fplus/curry_instances.autogenerated_defines ../third_party/FunctionalPlus/include_all_in_one/include/fplus/fplus.hpp /workspaces/project/build/third_party/FunctionalPlus/CMakeFiles/auto_generate /workspaces/project/third_party/FunctionalPlus/include/fplus/fwd_instances.autogenerated_defines /workspaces/project/third_party/FunctionalPlus/include/fplus/curry_instances.autogenerated_defines /workspaces/project/third_party/FunctionalPlus/include_all_in_one/include/fplus/fplus.hpp 
cd /workspaces/project/build/third_party/FunctionalPlus && /usr/bin/python3.10 /workspaces/project/third_party/FunctionalPlus/generate/auto_generate.py
Traceback (most recent call last):
  File "/workspaces/project/third_party/FunctionalPlus/generate/auto_generate.py", line 210, in <module>
    auto_generate()
  File "/workspaces/project/third_party/FunctionalPlus/generate/auto_generate.py", line 204, in auto_generate
    write_fwd_defines(all_function_and_bind_counts)
  File "/workspaces/project/third_party/FunctionalPlus/generate/auto_generate.py", line 180, in write_fwd_defines
    fwrite_content(FPLUS_INCLUDE_DIR + "/fwd_instances.autogenerated_defines", code)
  File "/workspaces/project/third_party/FunctionalPlus/generate/auto_generate.py", line 60, in fwrite_content
    old_content = fread_content(filename)
  File "/workspaces/project/third_party/FunctionalPlus/generate/auto_generate.py", line 48, in fread_content
    f = open(filename, "r", encoding='utf-8', errors='ignore')
FileNotFoundError: [Errno 2] No such file or directory: '/workspaces/project/third_party/FunctionalPlus/include/fplus/fwd_instances.autogenerated_defines'
```