### PR TITLE
Formatting CI check

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+---
+BasedOnStyle: WebKit

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,2 @@
+# Ignore generated files
+./include_all_in_one/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,14 @@ jobs:
       - name: Build
         shell: bash
         run: script/ci_build.sh
+
+
+  formatting-check:
+    name: "formatting"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: DoozyX/clang-format-lint-action@master
+        name: "Verify formatting"
+        with:
+          clangFormatVersion: 16

--- a/api_search/parse_source_files.cpp
+++ b/api_search/parse_source_files.cpp
@@ -206,7 +206,7 @@ int main(int argc, char* argv[])
     using fplus::transform;
     std::cout << "duplicate help names:" << std::endl;
     print_duplicates(transform(get_function_help_name, functions));
-    //print_duplicates(transform(get_function_help_signature, functions));
+    // print_duplicates(transform(get_function_help_signature, functions));
     std::cout << "duplicate help documentations:" << std::endl;
     print_duplicates(transform(get_function_help_documentation, functions));
     std::cout << "duplicate help declarations:" << std::endl;

--- a/include/fplus/internal/meta.hpp
+++ b/include/fplus/internal/meta.hpp
@@ -76,7 +76,7 @@ namespace internal {
 #ifndef PROVIDE_IS_FUNCTION_POLYFILL
     template <class... Any>
     using is_function = std::is_function<Any...>;
-#else //PROVIDE_IS_FUNCTION_POLYFILL
+#else // PROVIDE_IS_FUNCTION_POLYFILL
     // primary template
     template <class>
     struct is_function : std::false_type {
@@ -161,7 +161,7 @@ namespace internal {
     template <class Ret, class... Args>
     struct is_function<Ret(Args..., ...) const volatile&&> : std::true_type {
     };
-#endif //PROVIDE_IS_FUNCTION_POLYFILL
+#endif // PROVIDE_IS_FUNCTION_POLYFILL
 
     template <typename>
     struct reverse_integer_sequence_impl;

--- a/script/auto_format.sh
+++ b/script/auto_format.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-(find api_search -name "*.cpp" && find include -name "*.hpp" && find examples -name "*.cpp" && find test -name "*.cpp") | xargs clang-format --style=WebKit -i {}
+(find api_search -name "*.cpp" && find include -name "*.hpp" && find examples -name "*.cpp" && find test -name "*.cpp") | xargs clang-format -i {}

--- a/test/composition_test.cpp
+++ b/test/composition_test.cpp
@@ -165,8 +165,8 @@ TEST_CASE("composition_test - state")
     stateAdd(state, 2);
     REQUIRE_EQ(state.Get(), 3);
 
-    //auto stateAddBoundFPP = Bind1of2(stateAdd, &state); // crashes VC2015 compiler
-    //stateAddBoundFPP(3);
+    // auto stateAddBoundFPP = Bind1of2(stateAdd, &state); // crashes VC2015 compiler
+    // stateAddBoundFPP(3);
 
     auto stateAddBoundStl = std::bind(&CompositionTestState::Add, std::placeholders::_1, std::placeholders::_2);
     stateAddBoundStl(state, 3);

--- a/test/sets_test.cpp
+++ b/test/sets_test.cpp
@@ -16,7 +16,7 @@ TEST_CASE("set_test - set functions")
     using unordSetVector = std::vector<IntUnordSet>;
     using StringUnordSet = std::unordered_set<std::string>;
 
-    //std::set tests
+    // std::set tests
     REQUIRE(set_includes(IntSet({ 0, 1, 2, 3 }), IntSet({ 0, 2 })));
     REQUIRE_FALSE(set_includes(IntSet({ 0, 2 }), IntSet({ 0, 1, 2, 3 })));
     REQUIRE_FALSE(set_includes(IntSet({ 0, 1, 2, 3 }), IntSet({ 2, 3, 4, 5 })));
@@ -28,7 +28,7 @@ TEST_CASE("set_test - set functions")
     REQUIRE_EQ(set_intersection(IntSet({ 0, 1, 2, 3 }), IntSet({ 2, 3, 4, 5 })), IntSet({ 2, 3 }));
     REQUIRE_EQ(sets_intersection(setVector({ IntSet({ 0, 1, 2, 3 }), IntSet({ 2, 3, 4, 5 }), IntSet({ 0, 2 }) })), IntSet({ 2 }));
 
-    //set::unordered_set tests
+    // set::unordered_set tests
     REQUIRE(unordered_set_includes(IntUnordSet({ 0, 1, 2, 3 }), IntUnordSet({ 0, 2 })));
     REQUIRE_FALSE(unordered_set_includes(IntUnordSet({ 0, 2 }), IntUnordSet({ 0, 1, 2, 3 })));
     REQUIRE_FALSE(unordered_set_includes(IntUnordSet({ 0, 1, 2, 3 }), IntUnordSet({ 2, 3, 4, 5 })));

--- a/test/udemy_course_test.cpp
+++ b/test/udemy_course_test.cpp
@@ -473,7 +473,7 @@ std::function<int(int)> decorate_with_logging(const std::string& str, F f)
     return [str, f](int x) -> int {
         int result = f(x);
         // no side effects in tests
-        //std::cout << str << ": " << x << " => " << result << std::endl;
+        // std::cout << str << ": " << x << " => " << result << std::endl;
         return result;
     };
 }

--- a/test/variant_test.cpp
+++ b/test/variant_test.cpp
@@ -110,7 +110,7 @@ TEST_CASE("variant_test - visit")
     using namespace fplus;
 
     // should not compile
-    //int_or_double.visit_one<std::string>(print_string);
+    // int_or_double.visit_one<std::string>(print_string);
 
     fplus::variant<int, std::string> int_or_string(3);
 
@@ -131,16 +131,16 @@ TEST_CASE("variant_test - visit")
     std::cout << fplus::show_maybe(y) << std::endl;
 
     // should not compile
-    //std::cout << int_or_string.visit(show_int, show_float) << std::endl;
+    // std::cout << int_or_string.visit(show_int, show_float) << std::endl;
 
     // should not compile
-    //std::cout << int_or_string.visit(show_int, show_int) << std::endl;
+    // std::cout << int_or_string.visit(show_int, show_int) << std::endl;
 
     // should not compile
-    //std::cout << int_or_string.visit(show_int, show_string, show_double) << std::endl;
+    // std::cout << int_or_string.visit(show_int, show_string, show_double) << std::endl;
 
     // should not compile
-    //std::cout << int_or_string.visit(show_int) << std::endl;
+    // std::cout << int_or_string.visit(show_int) << std::endl;
 }
 
 TEST_CASE("variant_test - effect")
@@ -148,7 +148,7 @@ TEST_CASE("variant_test - effect")
     using namespace fplus;
 
     // should not compile
-    //int_or_double.effect_one(print_string);
+    // int_or_double.effect_one(print_string);
 
     fplus::variant<int, std::string> int_or_string(3);
     //


### PR DESCRIPTION
As mentioned in #291.

This checks the formatting as part of the CI build.

I have added `.clang-format` and `.clang-format-ignore` files to keep the configuration same, no matter how it clang-format is invoked (CI, script, editor, …).

There were some minor formatting issues left, which are corrected too.