### PR TITLE
Added noexcept variants to function traits

### DIFF
--- a/include/fplus/function_traits.hpp
+++ b/include/fplus/function_traits.hpp
@@ -145,7 +145,7 @@ namespace utils {
         };
     };
 
-#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+#if __cplusplus > 201510L
 
     template <typename ReturnType, typename... Args>
     struct function_traits<ReturnType(Args...) noexcept>
@@ -183,7 +183,7 @@ namespace utils {
         typedef const volatile ClassType& owner_type;
     };
 
-#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+#if __cplusplus > 201510L
 
     template <typename ReturnType, typename... Args>
     struct function_traits<ReturnType (*)(Args...) noexcept>
@@ -249,7 +249,7 @@ namespace utils {
     struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) const volatile>>
         : public function_traits<R(const volatile C*, A...)> {
     };
-#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+#if __cplusplus > 201510L
     template <typename R, typename C>
     struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)() noexcept>>
         : public function_traits<R(C*)> {
@@ -483,7 +483,7 @@ namespace internal {
     struct has_function_traits<std::function<FunctionType>> : std::true_type {
     };
 
-#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+#if __cplusplus > 201510L
 
     template <typename ReturnType, typename... Args>
     struct has_function_traits<ReturnType(Args...) noexcept> : std::true_type {

--- a/include/fplus/function_traits.hpp
+++ b/include/fplus/function_traits.hpp
@@ -145,10 +145,14 @@ namespace utils {
         };
     };
 
+#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+
     template <typename ReturnType, typename... Args>
     struct function_traits<ReturnType(Args...) noexcept>
         : public function_traits<ReturnType(Args...)> {
     };
+
+#endif
 
     template <typename ReturnType, typename... Args>
     struct function_traits<ReturnType (*)(Args...)>
@@ -179,6 +183,8 @@ namespace utils {
         typedef const volatile ClassType& owner_type;
     };
 
+#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+
     template <typename ReturnType, typename... Args>
     struct function_traits<ReturnType (*)(Args...) noexcept>
         : public function_traits<ReturnType(Args...)> {
@@ -207,6 +213,8 @@ namespace utils {
         : public function_traits<ReturnType(Args...)> {
         typedef const volatile ClassType& owner_type;
     };
+
+#endif
 
     template <typename FunctionType>
     struct function_traits<std::function<FunctionType>>
@@ -241,6 +249,7 @@ namespace utils {
     struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) const volatile>>
         : public function_traits<R(const volatile C*, A...)> {
     };
+#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
     template <typename R, typename C>
     struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)() noexcept>>
         : public function_traits<R(C*)> {
@@ -261,6 +270,7 @@ namespace utils {
     struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) const volatile noexcept>>
         : public function_traits<R(const volatile C*, A...)> {
     };
+#endif
 
 #undef MEM_FN_SYMBOL_XX0SL7G4Z0J
 #endif
@@ -473,6 +483,8 @@ namespace internal {
     struct has_function_traits<std::function<FunctionType>> : std::true_type {
     };
 
+#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+
     template <typename ReturnType, typename... Args>
     struct has_function_traits<ReturnType(Args...) noexcept> : std::true_type {
     };
@@ -501,21 +513,21 @@ namespace internal {
     };
 
     template <typename ReturnType, typename ClassType, typename... Args>
-    struct has_function_traits<ReturnType (ClassType::*)(Args...)& noexcept> : std::true_type {
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) & noexcept> : std::true_type {
     };
 
     template <typename ReturnType, typename ClassType, typename... Args>
-    struct has_function_traits<ReturnType (ClassType::*)(Args...) const& noexcept>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const & noexcept>
         : std::true_type {
     };
 
     template <typename ReturnType, typename ClassType, typename... Args>
-    struct has_function_traits<ReturnType (ClassType::*)(Args...) volatile& noexcept>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) volatile & noexcept>
         : std::true_type {
     };
 
     template <typename ReturnType, typename ClassType, typename... Args>
-    struct has_function_traits<ReturnType (ClassType::*)(Args...) const volatile& noexcept>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const volatile & noexcept>
         : std::true_type {
     };
 
@@ -525,19 +537,21 @@ namespace internal {
     };
 
     template <typename ReturnType, typename ClassType, typename... Args>
-    struct has_function_traits<ReturnType (ClassType::*)(Args...) const&& noexcept>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const && noexcept>
         : std::true_type {
     };
 
     template <typename ReturnType, typename ClassType, typename... Args>
-    struct has_function_traits<ReturnType (ClassType::*)(Args...) volatile&& noexcept>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) volatile && noexcept>
         : std::true_type {
     };
 
     template <typename ReturnType, typename ClassType, typename... Args>
-    struct has_function_traits<ReturnType (ClassType::*)(Args...) const volatile&& noexcept>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const volatile && noexcept>
         : std::true_type {
     };
+
+#endif
 }
 }
 

--- a/include/fplus/function_traits.hpp
+++ b/include/fplus/function_traits.hpp
@@ -146,6 +146,11 @@ namespace utils {
     };
 
     template <typename ReturnType, typename... Args>
+    struct function_traits<ReturnType(Args...) noexcept>
+        : public function_traits<ReturnType(Args...)> {
+    };
+
+    template <typename ReturnType, typename... Args>
     struct function_traits<ReturnType (*)(Args...)>
         : public function_traits<ReturnType(Args...)> {
     };
@@ -174,6 +179,35 @@ namespace utils {
         typedef const volatile ClassType& owner_type;
     };
 
+    template <typename ReturnType, typename... Args>
+    struct function_traits<ReturnType (*)(Args...) noexcept>
+        : public function_traits<ReturnType(Args...)> {
+    };
+
+    template <typename ClassType, typename ReturnType, typename... Args>
+    struct function_traits<ReturnType (ClassType::*)(Args...) noexcept>
+        : public function_traits<ReturnType(Args...)> {
+        typedef ClassType& owner_type;
+    };
+
+    template <typename ClassType, typename ReturnType, typename... Args>
+    struct function_traits<ReturnType (ClassType::*)(Args...) const noexcept>
+        : public function_traits<ReturnType(Args...)> {
+        typedef const ClassType& owner_type;
+    };
+
+    template <typename ClassType, typename ReturnType, typename... Args>
+    struct function_traits<ReturnType (ClassType::*)(Args...) volatile noexcept>
+        : public function_traits<ReturnType(Args...)> {
+        typedef volatile ClassType& owner_type;
+    };
+
+    template <typename ClassType, typename ReturnType, typename... Args>
+    struct function_traits<ReturnType (ClassType::*)(Args...) const volatile noexcept>
+        : public function_traits<ReturnType(Args...)> {
+        typedef const volatile ClassType& owner_type;
+    };
+
     template <typename FunctionType>
     struct function_traits<std::function<FunctionType>>
         : public function_traits<FunctionType> {
@@ -188,7 +222,7 @@ namespace utils {
 #ifdef MEM_FN_SYMBOL_XX0SL7G4Z0J
 
     template <typename R, typename C>
-    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R C::*>>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)()>>
         : public function_traits<R(C*)> {
     };
     template <typename R, typename C, typename... A>
@@ -205,6 +239,26 @@ namespace utils {
     };
     template <typename R, typename C, typename... A>
     struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) const volatile>>
+        : public function_traits<R(const volatile C*, A...)> {
+    };
+    template <typename R, typename C>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)() noexcept>>
+        : public function_traits<R(C*)> {
+    };
+    template <typename R, typename C, typename... A>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) noexcept>>
+        : public function_traits<R(C*, A...)> {
+    };
+    template <typename R, typename C, typename... A>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) const noexcept>>
+        : public function_traits<R(const C*, A...)> {
+    };
+    template <typename R, typename C, typename... A>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) volatile noexcept>>
+        : public function_traits<R(volatile C*, A...)> {
+    };
+    template <typename R, typename C, typename... A>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) const volatile noexcept>>
         : public function_traits<R(const volatile C*, A...)> {
     };
 
@@ -417,6 +471,72 @@ namespace internal {
 
     template <typename FunctionType>
     struct has_function_traits<std::function<FunctionType>> : std::true_type {
+    };
+
+    template <typename ReturnType, typename... Args>
+    struct has_function_traits<ReturnType(Args...) noexcept> : std::true_type {
+    };
+
+    template <typename ReturnType, typename... Args>
+    struct has_function_traits<ReturnType (*)(Args...) noexcept> : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) noexcept> : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) volatile noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const volatile noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...)& noexcept> : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const& noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) volatile& noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const volatile& noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) && noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const&& noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) volatile&& noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const volatile&& noexcept>
+        : std::true_type {
     };
 }
 }

--- a/include_all_in_one/include/fplus/fplus.hpp
+++ b/include_all_in_one/include/fplus/fplus.hpp
@@ -404,7 +404,7 @@ namespace utils {
         };
     };
 
-#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+#if __cplusplus > 201510L
 
     template <typename ReturnType, typename... Args>
     struct function_traits<ReturnType(Args...) noexcept>
@@ -442,7 +442,7 @@ namespace utils {
         typedef const volatile ClassType& owner_type;
     };
 
-#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+#if __cplusplus > 201510L
 
     template <typename ReturnType, typename... Args>
     struct function_traits<ReturnType (*)(Args...) noexcept>
@@ -508,7 +508,7 @@ namespace utils {
     struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) const volatile>>
         : public function_traits<R(const volatile C*, A...)> {
     };
-#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+#if __cplusplus > 201510L
     template <typename R, typename C>
     struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)() noexcept>>
         : public function_traits<R(C*)> {
@@ -742,7 +742,7 @@ namespace internal {
     struct has_function_traits<std::function<FunctionType>> : std::true_type {
     };
 
-#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+#if __cplusplus > 201510L
 
     template <typename ReturnType, typename... Args>
     struct has_function_traits<ReturnType(Args...) noexcept> : std::true_type {

--- a/include_all_in_one/include/fplus/fplus.hpp
+++ b/include_all_in_one/include/fplus/fplus.hpp
@@ -404,6 +404,15 @@ namespace utils {
         };
     };
 
+#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+
+    template <typename ReturnType, typename... Args>
+    struct function_traits<ReturnType(Args...) noexcept>
+        : public function_traits<ReturnType(Args...)> {
+    };
+
+#endif
+
     template <typename ReturnType, typename... Args>
     struct function_traits<ReturnType (*)(Args...)>
         : public function_traits<ReturnType(Args...)> {
@@ -433,6 +442,39 @@ namespace utils {
         typedef const volatile ClassType& owner_type;
     };
 
+#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+
+    template <typename ReturnType, typename... Args>
+    struct function_traits<ReturnType (*)(Args...) noexcept>
+        : public function_traits<ReturnType(Args...)> {
+    };
+
+    template <typename ClassType, typename ReturnType, typename... Args>
+    struct function_traits<ReturnType (ClassType::*)(Args...) noexcept>
+        : public function_traits<ReturnType(Args...)> {
+        typedef ClassType& owner_type;
+    };
+
+    template <typename ClassType, typename ReturnType, typename... Args>
+    struct function_traits<ReturnType (ClassType::*)(Args...) const noexcept>
+        : public function_traits<ReturnType(Args...)> {
+        typedef const ClassType& owner_type;
+    };
+
+    template <typename ClassType, typename ReturnType, typename... Args>
+    struct function_traits<ReturnType (ClassType::*)(Args...) volatile noexcept>
+        : public function_traits<ReturnType(Args...)> {
+        typedef volatile ClassType& owner_type;
+    };
+
+    template <typename ClassType, typename ReturnType, typename... Args>
+    struct function_traits<ReturnType (ClassType::*)(Args...) const volatile noexcept>
+        : public function_traits<ReturnType(Args...)> {
+        typedef const volatile ClassType& owner_type;
+    };
+
+#endif
+
     template <typename FunctionType>
     struct function_traits<std::function<FunctionType>>
         : public function_traits<FunctionType> {
@@ -447,7 +489,7 @@ namespace utils {
 #ifdef MEM_FN_SYMBOL_XX0SL7G4Z0J
 
     template <typename R, typename C>
-    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R C::*>>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)()>>
         : public function_traits<R(C*)> {
     };
     template <typename R, typename C, typename... A>
@@ -466,6 +508,28 @@ namespace utils {
     struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) const volatile>>
         : public function_traits<R(const volatile C*, A...)> {
     };
+#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+    template <typename R, typename C>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)() noexcept>>
+        : public function_traits<R(C*)> {
+    };
+    template <typename R, typename C, typename... A>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) noexcept>>
+        : public function_traits<R(C*, A...)> {
+    };
+    template <typename R, typename C, typename... A>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) const noexcept>>
+        : public function_traits<R(const C*, A...)> {
+    };
+    template <typename R, typename C, typename... A>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) volatile noexcept>>
+        : public function_traits<R(volatile C*, A...)> {
+    };
+    template <typename R, typename C, typename... A>
+    struct function_traits<MEM_FN_SYMBOL_XX0SL7G4Z0J<R (C::*)(A...) const volatile noexcept>>
+        : public function_traits<R(const volatile C*, A...)> {
+    };
+#endif
 
 #undef MEM_FN_SYMBOL_XX0SL7G4Z0J
 #endif
@@ -677,6 +741,76 @@ namespace internal {
     template <typename FunctionType>
     struct has_function_traits<std::function<FunctionType>> : std::true_type {
     };
+
+#if ((defined(__GNUC__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 16)) && !defined(_MSC_VER)
+
+    template <typename ReturnType, typename... Args>
+    struct has_function_traits<ReturnType(Args...) noexcept> : std::true_type {
+    };
+
+    template <typename ReturnType, typename... Args>
+    struct has_function_traits<ReturnType (*)(Args...) noexcept> : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) noexcept> : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) volatile noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const volatile noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) & noexcept> : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const & noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) volatile & noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const volatile & noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) && noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const && noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) volatile && noexcept>
+        : std::true_type {
+    };
+
+    template <typename ReturnType, typename ClassType, typename... Args>
+    struct has_function_traits<ReturnType (ClassType::*)(Args...) const volatile && noexcept>
+        : std::true_type {
+    };
+
+#endif
 }
 }
 

--- a/test/function_traits_test.cpp
+++ b/test/function_traits_test.cpp
@@ -21,12 +21,24 @@ std::string CcI2SFree(const std::string& str, int x)
     return str + std::to_string(x);
 }
 
+std::string CcI2SFreeNoexcept(const std::string& str, int x) noexcept
+{
+    return str + std::to_string(x);
+}
+
 auto CcI2SLambda = [](const std::string& str, int x) { return CcI2SFree(str, x); };
+
+auto CcI2SLambdaNoexcept = [](const std::string& str, int x) noexcept { return CcI2SFree(str, x); };
 
 std::function<std::string(const std::string&, int)>
     CcI2SStdFunction = CcI2SLambda;
 
+std::function<std::string(const std::string&, int)>
+    CcI2SStdFunctionNoexcept = CcI2SLambdaNoexcept;
+
 std::string (*CcI2SFunctionPointer)(const std::string&, int) = &CcI2SFree;
+
+std::string (*CcI2SFunctionPointerNoexcept)(const std::string&, int) noexcept = &CcI2SFreeNoexcept;
 
 struct CcI2SStrct {
     std::string operator()(const std::string& str, int x)
@@ -44,6 +56,25 @@ struct CcI2SStrct {
     static std::string sttcMemF(const std::string& str, int x)
     {
         return CcI2SFree(str, x);
+    }
+};
+
+struct CcI2SStrctNoexcept {
+    std::string operator()(const std::string& str, int x) noexcept
+    {
+        return CcI2SFreeNoexcept(str, x);
+    }
+    std::string nonCMemF(const std::string& str, int x) noexcept
+    {
+        return CcI2SFreeNoexcept(str, x);
+    }
+    std::string cnstMemF(const std::string& str, int x) const noexcept
+    {
+        return CcI2SFreeNoexcept(str, x);
+    }
+    static std::string sttcMemF(const std::string& str, int x) noexcept
+    {
+        return CcI2SFreeNoexcept(str, x);
     }
 };
 
@@ -102,6 +133,58 @@ TEST_CASE("function_traits_test - static_asserts")
                       std::string>::value,
         "No.");
 
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SFreeNoexcept)>::arg<0>::type,
+                      const std::string&>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SFreeNoexcept)>::arg<1>::type,
+                      int>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SFreeNoexcept)>::result_type,
+                      std::string>::value,
+        "No.");
+
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SLambdaNoexcept)>::arg<0>::type,
+                      const std::string&>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SLambdaNoexcept)>::arg<1>::type,
+                      int>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SLambdaNoexcept)>::result_type,
+                      std::string>::value,
+        "No.");
+
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SStdFunctionNoexcept)>::arg<0>::type,
+                      const std::string&>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SStdFunctionNoexcept)>::arg<1>::type,
+                      int>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SStdFunctionNoexcept)>::result_type,
+                      std::string>::value,
+        "No.");
+
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SFunctionPointerNoexcept)>::arg<0>::type,
+                      const std::string&>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SFunctionPointerNoexcept)>::arg<1>::type,
+                      int>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(CcI2SFunctionPointerNoexcept)>::result_type,
+                      std::string>::value,
+        "No.");
+
     CcI2SStrct ccI2SStrct;
     ccI2SStrct("dummy call to avoid unused variable warnings", 0);
     static_assert(std::is_same<
@@ -153,6 +236,60 @@ TEST_CASE("function_traits_test - static_asserts")
         "No.");
     static_assert(std::is_same<
                       utils::function_traits<decltype(&CcI2SStrct::sttcMemF)>::result_type,
+                      std::string>::value,
+        "No.");
+
+    CcI2SStrctNoexcept ccI2SStrctNoexcept;
+    ccI2SStrctNoexcept("dummy call to avoid unused variable warnings", 0);
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(ccI2SStrctNoexcept)>::arg<0>::type,
+                      const std::string&>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(ccI2SStrctNoexcept)>::arg<1>::type,
+                      int>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(ccI2SStrctNoexcept)>::result_type,
+                      std::string>::value,
+        "No.");
+
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(&CcI2SStrctNoexcept::nonCMemF)>::arg<0>::type,
+                      const std::string&>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(&CcI2SStrctNoexcept::nonCMemF)>::arg<1>::type,
+                      int>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(&CcI2SStrctNoexcept::nonCMemF)>::result_type,
+                      std::string>::value,
+        "No.");
+
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(&CcI2SStrctNoexcept::cnstMemF)>::arg<0>::type,
+                      const std::string&>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(&CcI2SStrctNoexcept::cnstMemF)>::arg<1>::type,
+                      int>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(&CcI2SStrctNoexcept::cnstMemF)>::result_type,
+                      std::string>::value,
+        "No.");
+
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(&CcI2SStrctNoexcept::sttcMemF)>::arg<0>::type,
+                      const std::string&>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(&CcI2SStrctNoexcept::sttcMemF)>::arg<1>::type,
+                      int>::value,
+        "No.");
+    static_assert(std::is_same<
+                      utils::function_traits<decltype(&CcI2SStrctNoexcept::sttcMemF)>::result_type,
                       std::string>::value,
         "No.");
 }


### PR DESCRIPTION
When using `function_traits` with callable items that are noexcept, no specialization would match. Here is a simple reproduction case for this.
```cpp
#include <iostream>
#include <functional>

#include "fplus/fplus.hpp"

template<typename F, typename T = typename fplus::utils::function_traits<F>::template arg<0>::type>
auto forward(F f) {
  return [f](auto x) {
    auto ret = f(x);
    return ret;
  };
}

class klass {
  public:
    int x;

    int normal() const {
      return x;
    }

    int noexc() const noexcept {
      return x;
    }
};

int half(int x) {
  return x / 2;
}

int half_noexc(int x) noexcept {
  return x / 2;
}

struct functor {
  int operator()(int x) {
    return x + 5;
  }
};

struct functor_noexc {
  int operator()(int x) noexcept {
    return x + 5;
  }
};

int main() {
  klass k = {42};
  std::cout << forward(std::mem_fn(&klass::normal))(k) << std::endl; // OK
  std::cout << forward(std::mem_fn(&klass::noexc))(k) << std::endl; // Will not compile
  std::cout << forward(half)(42) << std::endl; // OK
  std::cout << forward(half_noexc)(42) << std::endl; // Will not compile
  std::cout << forward(functor())(42) << std::endl; // OK
  std::cout << forward(functor_noexc())(42) << std::endl; // Will not compile
  auto lambda = [](int x) {
    return x + 10;
  };
  auto lambda_noexc = [](int x) noexcept {
    return x + 10;
  };
  std::cout << forward(lambda)(42) << std::endl; // OK
  std::cout << forward(lambda_noexc)(42) << std::endl; // Will not compile
}
```

### EDIT

Sorry for recreating the pull request. I finally figured out the CI and also wanted to rebase the branch to tidy the commits.

This version should compile for all compilers in the CI.