### PR TITLE
Remove use of `_Is_checked_helper` since VS 2019 15.8 1915

### DIFF
--- a/include/fplus/container_common.hpp
+++ b/include/fplus/container_common.hpp
@@ -193,7 +193,7 @@ namespace internal {
         std::size_t pos_;
     };
 
-#if defined(_MSC_VER) && _MSC_VER >= 1900
+#if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 1915
     template <typename T, std::size_t N>
     struct std::_Is_checked_helper<array_back_insert_iterator<T, N>>
         : public true_type { // mark array_back_insert_iterator as checked


### PR DESCRIPTION
Since VS 2019 15.8 1915, `_Is_checked_helper` became meaningless. Per microsoft/STL#5081, it's planned that `_Is_checked_helper` will be completely removed, so I think we should just stop using it.