### PR TITLE
Replace EOL windows-2019 CI build and add windows-2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,8 @@ jobs:
     strategy:
       matrix:
         msvc_version:
-          - 2019
           - 2022
+          - 2025
     name: "Windows ${{ matrix.msvc_version }} MSVC"
     steps:
       - uses: actions/checkout@main


### PR DESCRIPTION
Windows 2019 is EOL and will be removed end of this month

> The windows-2019 runner image is being deprecated, consider switching to windows-2022(windows-latest) or windows-2025 instead. For more details see https://github.com/actions/runner-images/issues/12045.

There are scheduled brownouts already:

> This is a scheduled Windows Server 2019 brownout. The Windows Server 2019 image will be removed on 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045

