### PR TITLE
Add compose_first_error_and_result, closes #265

### DIFF
--- a/include/fplus/result.hpp
+++ b/include/fplus/result.hpp
@@ -346,4 +346,24 @@ auto compose_result(Callables&&... callables)
     return internal::compose_binary_lift(bind_result,
         std::forward<Callables>(callables)...);
 }
+
+// API search type: compose_log_and_result : ((a -> Result b c), (a -> Result d e)) -> (a -> (Maybe c, Result d e))
+// Pair a possibly-failing side-effecting function (e.g. logging) with a
+// regular result-returning function. Both are called with the same input,
+// and the second is called regardless of whether the first one failed.
+// The Ok value of the first function is discarded; only its potential
+// error is preserved, as a Maybe (nothing if the side effect succeeded).
+// The result of the second function is forwarded unchanged.
+template <typename Log, typename Func>
+auto compose_log_and_result(Log log, Func func)
+{
+    return [log = std::move(log), func = std::move(func)](const auto& x) {
+        auto log_result = internal::invoke(log, x);
+        using LogErr = typename std::decay_t<decltype(log_result)>::error_t;
+        auto log_err = is_error(log_result)
+            ? just<LogErr>(unsafe_get_error(log_result))
+            : nothing<LogErr>();
+        return std::make_pair(std::move(log_err), internal::invoke(func, x));
+    };
+}
 } // namespace fplus

--- a/include/fplus/result.hpp
+++ b/include/fplus/result.hpp
@@ -347,23 +347,24 @@ auto compose_result(Callables&&... callables)
         std::forward<Callables>(callables)...);
 }
 
-// API search type: compose_log_and_result : ((a -> Result b c), (a -> Result d e)) -> (a -> (Maybe c, Result d e))
-// Pair a possibly-failing side-effecting function (e.g. logging) with a
-// regular result-returning function. Both are called with the same input,
-// and the second is called regardless of whether the first one failed.
-// The Ok value of the first function is discarded; only its potential
-// error is preserved, as a Maybe (nothing if the side effect succeeded).
-// The result of the second function is forwarded unchanged.
-template <typename Log, typename Func>
-auto compose_log_and_result(Log log, Func func)
+// API search type: compose_first_error_and_result : ((a -> Result b c), (a -> Result d e)) -> (a -> (Maybe c, Result d e))
+// Run two result-returning functions on the same input independently.
+// The first contributes only its potential error (as a Maybe), its Ok
+// value is discarded. The second's result is forwarded unchanged.
+// The second function is always called, regardless of whether the first
+// one failed. Useful for ancillary checks (logging, metrics, validation,
+// audit, cache lookup, ...) that may fail but should not block the main
+// computation.
+template <typename First, typename Second>
+auto compose_first_error_and_result(First first, Second second)
 {
-    return [log = std::move(log), func = std::move(func)](const auto& x) {
-        auto log_result = internal::invoke(log, x);
-        using LogErr = typename std::decay_t<decltype(log_result)>::error_t;
-        auto log_err = is_error(log_result)
-            ? just<LogErr>(unsafe_get_error(log_result))
-            : nothing<LogErr>();
-        return std::make_pair(std::move(log_err), internal::invoke(func, x));
+    return [first = std::move(first), second = std::move(second)](const auto& x) {
+        auto first_result = internal::invoke(first, x);
+        using FirstErr = typename std::decay_t<decltype(first_result)>::error_t;
+        auto first_err = is_error(first_result)
+            ? just<FirstErr>(unsafe_get_error(first_result))
+            : nothing<FirstErr>();
+        return std::make_pair(std::move(first_err), internal::invoke(second, x));
     };
 }
 } // namespace fplus

--- a/include_all_in_one/include/fplus/fplus.hpp
+++ b/include_all_in_one/include/fplus/fplus.hpp
@@ -5719,6 +5719,26 @@ auto compose_result(Callables&&... callables)
     return internal::compose_binary_lift(bind_result,
         std::forward<Callables>(callables)...);
 }
+
+// API search type: compose_log_and_result : ((a -> Result b c), (a -> Result d e)) -> (a -> (Maybe c, Result d e))
+// Pair a possibly-failing side-effecting function (e.g. logging) with a
+// regular result-returning function. Both are called with the same input,
+// and the second is called regardless of whether the first one failed.
+// The Ok value of the first function is discarded; only its potential
+// error is preserved, as a Maybe (nothing if the side effect succeeded).
+// The result of the second function is forwarded unchanged.
+template <typename Log, typename Func>
+auto compose_log_and_result(Log log, Func func)
+{
+    return [log = std::move(log), func = std::move(func)](const auto& x) {
+        auto log_result = internal::invoke(log, x);
+        using LogErr = typename std::decay_t<decltype(log_result)>::error_t;
+        auto log_err = is_error(log_result)
+            ? just<LogErr>(unsafe_get_error(log_result))
+            : nothing<LogErr>();
+        return std::make_pair(std::move(log_err), internal::invoke(func, x));
+    };
+}
 } // namespace fplus
 
 #include <algorithm>

--- a/include_all_in_one/include/fplus/fplus.hpp
+++ b/include_all_in_one/include/fplus/fplus.hpp
@@ -5720,23 +5720,24 @@ auto compose_result(Callables&&... callables)
         std::forward<Callables>(callables)...);
 }
 
-// API search type: compose_log_and_result : ((a -> Result b c), (a -> Result d e)) -> (a -> (Maybe c, Result d e))
-// Pair a possibly-failing side-effecting function (e.g. logging) with a
-// regular result-returning function. Both are called with the same input,
-// and the second is called regardless of whether the first one failed.
-// The Ok value of the first function is discarded; only its potential
-// error is preserved, as a Maybe (nothing if the side effect succeeded).
-// The result of the second function is forwarded unchanged.
-template <typename Log, typename Func>
-auto compose_log_and_result(Log log, Func func)
+// API search type: compose_first_error_and_result : ((a -> Result b c), (a -> Result d e)) -> (a -> (Maybe c, Result d e))
+// Run two result-returning functions on the same input independently.
+// The first contributes only its potential error (as a Maybe), its Ok
+// value is discarded. The second's result is forwarded unchanged.
+// The second function is always called, regardless of whether the first
+// one failed. Useful for ancillary checks (logging, metrics, validation,
+// audit, cache lookup, ...) that may fail but should not block the main
+// computation.
+template <typename First, typename Second>
+auto compose_first_error_and_result(First first, Second second)
 {
-    return [log = std::move(log), func = std::move(func)](const auto& x) {
-        auto log_result = internal::invoke(log, x);
-        using LogErr = typename std::decay_t<decltype(log_result)>::error_t;
-        auto log_err = is_error(log_result)
-            ? just<LogErr>(unsafe_get_error(log_result))
-            : nothing<LogErr>();
-        return std::make_pair(std::move(log_err), internal::invoke(func, x));
+    return [first = std::move(first), second = std::move(second)](const auto& x) {
+        auto first_result = internal::invoke(first, x);
+        using FirstErr = typename std::decay_t<decltype(first_result)>::error_t;
+        auto first_err = is_error(first_result)
+            ? just<FirstErr>(unsafe_get_error(first_result))
+            : nothing<FirstErr>();
+        return std::make_pair(std::move(first_err), internal::invoke(second, x));
     };
 }
 } // namespace fplus

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -6,7 +6,6 @@
 
 #include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
-#include <variant>
 #include <vector>
 
 namespace {
@@ -122,10 +121,10 @@ TEST_CASE("result_test - compose_first_error_and_result")
     using namespace fplus;
 
     const auto check_ok = [](int) {
-        return ok<std::monostate, std::string>({});
+        return ok<int, std::string>(0);
     };
     const auto check_fail = [](int) {
-        return error<std::monostate, std::string>("check failed");
+        return error<int, std::string>("check failed");
     };
     const auto run = [](int x) {
         return x < 0

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -117,15 +117,15 @@ TEST_CASE("result_test - compose_result")
     REQUIRE_EQ(squareSumResult(5, 5), (ok<int, std::string>(100)));
 }
 
-TEST_CASE("result_test - compose_log_and_result")
+TEST_CASE("result_test - compose_first_error_and_result")
 {
     using namespace fplus;
 
-    const auto log_ok = [](int) {
+    const auto check_ok = [](int) {
         return ok<std::monostate, std::string>({});
     };
-    const auto log_fail = [](int) {
-        return error<std::monostate, std::string>("log failed");
+    const auto check_fail = [](int) {
+        return error<std::monostate, std::string>("check failed");
     };
     const auto run = [](int x) {
         return x < 0
@@ -135,14 +135,14 @@ TEST_CASE("result_test - compose_log_and_result")
 
     using Pair = std::pair<maybe<std::string>, result<int, std::string>>;
 
-    REQUIRE_EQ(compose_log_and_result(log_ok, run)(3),
+    REQUIRE_EQ(compose_first_error_and_result(check_ok, run)(3),
         Pair(nothing<std::string>(), ok<int, std::string>(9)));
-    REQUIRE_EQ(compose_log_and_result(log_ok, run)(-1),
+    REQUIRE_EQ(compose_first_error_and_result(check_ok, run)(-1),
         Pair(nothing<std::string>(), error<int, std::string>("negative input")));
-    REQUIRE_EQ(compose_log_and_result(log_fail, run)(3),
-        Pair(just<std::string>("log failed"), ok<int, std::string>(9)));
-    REQUIRE_EQ(compose_log_and_result(log_fail, run)(-1),
-        Pair(just<std::string>("log failed"), error<int, std::string>("negative input")));
+    REQUIRE_EQ(compose_first_error_and_result(check_fail, run)(3),
+        Pair(just<std::string>("check failed"), ok<int, std::string>(9)));
+    REQUIRE_EQ(compose_first_error_and_result(check_fail, run)(-1),
+        Pair(just<std::string>("check failed"), error<int, std::string>("negative input")));
 }
 
 TEST_CASE("result_test - lift")

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -6,6 +6,7 @@
 
 #include <doctest/doctest.h>
 #include <fplus/fplus.hpp>
+#include <variant>
 #include <vector>
 
 namespace {
@@ -114,6 +115,34 @@ TEST_CASE("result_test - compose_result")
     });
 
     REQUIRE_EQ(squareSumResult(5, 5), (ok<int, std::string>(100)));
+}
+
+TEST_CASE("result_test - compose_log_and_result")
+{
+    using namespace fplus;
+
+    const auto log_ok = [](int) {
+        return ok<std::monostate, std::string>({});
+    };
+    const auto log_fail = [](int) {
+        return error<std::monostate, std::string>("log failed");
+    };
+    const auto run = [](int x) {
+        return x < 0
+            ? error<int, std::string>("negative input")
+            : ok<int, std::string>(x * x);
+    };
+
+    using Pair = std::pair<maybe<std::string>, result<int, std::string>>;
+
+    REQUIRE_EQ(compose_log_and_result(log_ok, run)(3),
+        Pair(nothing<std::string>(), ok<int, std::string>(9)));
+    REQUIRE_EQ(compose_log_and_result(log_ok, run)(-1),
+        Pair(nothing<std::string>(), error<int, std::string>("negative input")));
+    REQUIRE_EQ(compose_log_and_result(log_fail, run)(3),
+        Pair(just<std::string>("log failed"), ok<int, std::string>(9)));
+    REQUIRE_EQ(compose_log_and_result(log_fail, run)(-1),
+        Pair(just<std::string>("log failed"), error<int, std::string>("negative input")));
 }
 
 TEST_CASE("result_test - lift")


### PR DESCRIPTION
## Summary
- Adds `compose_first_error_and_result` in `result.hpp`: runs two `Result`-returning functions on the same input independently.
- The first contributes only its potential error (as `Maybe`); its Ok value is discarded.
- The second's `Result` is forwarded unchanged, and the second is always called regardless of whether the first failed.
- Useful for ancillary checks (logging, metrics, validation, audit, cache lookup, ...) that may fail but should not block the main computation.

```cpp
// first  : a -> Result<X, E1>     (Ok value is discarded; only error is captured)
// second : a -> Result<T, E2>     (called regardless of whether first failed)
// returns: a -> std::pair<Maybe<E1>, Result<T, E2>>
```

Resolves the design discussed in #265.

## Test plan
- [x] New `result_test - compose_first_error_and_result` test case covers all four combinations: (first ok / fail) × (second ok / fail).
- [x] Full test suite passes (`ctest`: 424/424).
- [x] `generate/auto_generate.py` ran; amalgamated `include_all_in_one/include/fplus/fplus.hpp` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)