### PR TITLE
Bump version to 0.2.28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(FunctionalPlus VERSION 0.2.27)
+project(FunctionalPlus VERSION 0.2.28)
 
 # ---- Warning guard ----
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -154,7 +154,7 @@ Just add a *conanfile.txt* with FunctionalPlus as a requirement and chose the ge
 
 ```
 [requires]
-functionalplus/0.2.27
+functionalplus/0.2.28
 
 [generators]
 cmake


### PR DESCRIPTION
## Summary
Releases v0.2.28. Bumps the version in `CMakeLists.txt` and the Conan example in `INSTALL.md`.

Changes shipping in this release (since v0.2.27):
- Add `compose_first_error_and_result` (#329, closes #265)
- Add Clang 22 CI build (#326)
- Document include-path collision workaround in INSTALL.md (#330, refs #222)
- Scripts: fail on error (#327)

## Test plan
- [x] CMake configures and builds
- [x] CI must pass before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)