### PR TITLE
Replace inactive MSVC action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,9 @@ jobs:
     name: "Windows ${{ matrix.msvc_version }} MSVC"
     steps:
       - uses: actions/checkout@main
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: TheMrMilchmann/setup-msvc-dev@v4
+        with:
+          arch: x64
       - name: Build and Test
         shell: bash
         run: script/ci.sh run_tests


### PR DESCRIPTION
Addresses this warning on the MSVC builds:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: ilammy/msvc-dev-cmd@v1. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/